### PR TITLE
chore(iap): Play Billing 8 migration + 8.1.1 release build

### DIFF
--- a/.github/workflows/flutter_build.yml
+++ b/.github/workflows/flutter_build.yml
@@ -23,6 +23,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.44.9'
           cache: true
 
       - name: Install Dependencies
@@ -75,6 +76,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.44.9'
           cache: true
 
       - name: Install Dependencies

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -114,7 +114,6 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.10.0')
     implementation 'com.google.firebase:firebase-analytics'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
-    implementation 'com.android.billingclient:billing:7.1.1'
     implementation 'com.google.firebase:firebase-auth'
     implementation 'com.google.firebase:firebase-firestore'
     implementation 'com.google.firebase:firebase-functions'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.0+810
+version: 8.1.1+811
 environment:
   sdk: '>=3.4.3 <4.0.0'
 
@@ -36,9 +36,9 @@ dependencies:
   firebase_messaging: ^16.0.2
 
   # --- IN-APP PURCHASE ---
-  in_app_purchase: ^3.2.3
-  in_app_purchase_android: ^0.4.0+8
-  in_app_purchase_storekit: ^0.4.6+2
+  in_app_purchase: ^3.3.0
+  in_app_purchase_android: ^0.5.3
+  in_app_purchase_storekit: ^0.4.11+2
   in_app_review: ^2.0.10
 
   # --- DEVICE & UTILITIES ---


### PR DESCRIPTION
## Why

Two separate problems were blocking the 8.1.1 release.

### 1 · Play Billing was pinned to 7.1.1

`android/app/build.gradle` carried an explicit line:

```gradle
implementation 'com.android.billingclient:billing:7.1.1'
```

This held the app on Billing 7 regardless of the Flutter plugin version. Nothing in the native code references `BillingClient`, so the declaration was redundant — it only held the version back. Removed; `in_app_purchase_android` now owns the Billing version and it cannot drift again.

The pubspec constraint `in_app_purchase_android: ^0.4.0+8` also capped resolution below 0.5.0, which in turn forced `in_app_purchase` down to 3.2.x (3.3.0 requires `^0.5.0`).

| package | before | after |
|---|---|---|
| `in_app_purchase` | `^3.2.3` | `^3.3.0` |
| `in_app_purchase_android` | `^0.4.0+8` | `^0.5.3` |
| `in_app_purchase_storekit` | `^0.4.6+2` | `^0.4.11+2` |
| `version` | `8.1.0+810` | `8.1.1+811` |

**No Dart changes were required.** None of the APIs removed in 0.5.0 (`queryPurchaseHistory`, `ProrationMode`, `enablePendingPurchases`) are used, `ReplacementMode` was already correct, and `queryPastPurchases()` still exists in 0.5.3. The Android config already satisfies Billing 8: compileSdk 36, minSdk 26, AGP 8.11.1, Gradle 8.14, Java 21.

### 2 · CI had been broken for three weeks

Both jobs set `channel: stable` without pinning a version, so the runner silently followed stable forward from 3.44.9 (the last green build, 2026-08-09) to 3.47.2. Under 3.47.2 the Dart front end rejects `pdfrx 1.3.5`:

```
pdfrx-1.3.5/lib/src/pdfium/pdf_file_cache.dart:351:63:
Error: Property 'blockSize' cannot be accessed on 'PdfFileCache?'
because it is potentially null.
```

Android fails at `:app:compileFlutterBuildRelease` and iOS at `kernel_snapshot_program` — the same compile, both jobs. `pubspec.lock` has pinned pdfrx at 1.3.5 throughout, so this is **toolchain drift**, not a dependency change.

Flutter is pinned to the last working version.

**This is a stopgap.** The real fix is moving to pdfrx 2.x, but 2.x replaces the text extraction API that `lib/rag/extractors.dart` uses (`page.loadText()` / `fullText`), so that needs its own change.

## Verification

CI is green on this branch and both artifacts were produced. Read from **inside** the AAB:

```
com.android.billingclient : billing : 8.0.0
versionName: 8.1.1
```

Versions CI resolved:

```
> in_app_purchase          3.3.0     (was 3.2.3)
> in_app_purchase_android  0.5.3     (was 0.4.0+10)
> in_app_purchase_storekit 0.4.11+2  (was 0.4.8+1)
Flutter: stable-3.44.9
```

## Before uploading

Confirm the highest existing versionCode on Play is below 811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
