### PR TITLE
feat: Deepgram dictation, ElevenLabs voice, billing v2 client

### DIFF
--- a/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -171,6 +171,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin play_install_referrer, com.chunkytofustudios.play_install_referrer.PlayInstallReferrerPlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new com.llfbandit.record.RecordPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin record_android, com.llfbandit.record.RecordPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new dev.fluttercommunity.plus.share.SharePlusPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin share_plus, dev.fluttercommunity.plus.share.SharePlusPlugin", e);

--- a/lib/chat/messages/options/change.dart
+++ b/lib/chat/messages/options/change.dart
@@ -54,9 +54,10 @@ Future<void> showModelSelectionDialog({
     return m.attachmentPaths.any((path) => _isImageFile(path));
   });
 
-  // Premium access: subscribed OR has predits balance > 0
+  // Premium access. Billing v2 has no premium lane — anything the user can
+  // afford is allowed — so this asks the balance, not a separate currency.
   final hasPremiumAccess = session.isUserSubscribed ||
-      (context.read<CreditsManager>().preditsNotifier.value ?? 0) > 0;
+      context.read<CreditsManager>().canUsePremiumModel;
   final Set<String> downloadedModelIds =
       (await UserModels.loadDownloadedModelPaths()).keys.toSet();
 

--- a/lib/chat/messages/options/panel.dart
+++ b/lib/chat/messages/options/panel.dart
@@ -114,9 +114,10 @@ class OptionsPanelViewModel {
     final isDynamicContext = session.isDynamicChat;
     final isOfflineModel = modelSeriesData?.isServerSide == false;
 
-    // We check predits from the viewmodel directly
+    // Billing v2 has no premium lane, so this is a balance question. The
+    // getter keeps the old predit check for unmigrated accounts.
     final hasPreditsForPremium = session.isUserSubscribed ||
-        (context.read<CreditsManager>().preditsNotifier.value ?? 0) > 0;
+        context.read<CreditsManager>().canUsePremiumModel;
 
     final isCurrentModelPremium = currentModel.isPremium;
 

--- a/lib/chat/screen/widgets/bottom/input/service.dart
+++ b/lib/chat/screen/widgets/bottom/input/service.dart
@@ -5,6 +5,7 @@ import 'package:cortex/chat/providers/input.dart';
 import 'package:cortex/chat/providers/session.dart';
 import 'package:cortex/library/backend/data/entity.dart';
 import 'package:cortex/l10n/app_localizations.dart';
+import 'package:cortex/server/credits.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
@@ -330,18 +331,23 @@ class InputService {
       return false;
     }
 
-    // 2. Premium / Predits Limits
-    // Dynamic chat is gated by dredits only on the client. The server may still
-    // spend predits/credits after routing if it chooses a premium provider.
+    // 2. Credit gate
+    //
+    // Billing v2 retired the premium lane and the Dynamic Chat currency: every
+    // model bills its real cost against one balance, so both cases collapse
+    // into "can they afford to start a text request". canUsePremiumModel and
+    // canSendDynamicChat keep the pre-migration behaviour for accounts the
+    // lazy migration has not touched yet.
+    final creditsManager = context.read<CreditsManager>();
+
     if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
-      if ((availablePredits ?? 0) < 10) {
+      if (!creditsManager.canUsePremiumModel) {
         return false;
       }
     }
 
-    // 3. Dynamic Chat / Dredits Limit
     if (isDynamicChatMode) {
-      if ((availableDredits ?? 0) < 1) {
+      if (!creditsManager.canSendDynamicChat) {
         return false;
       }
     }
@@ -402,18 +408,23 @@ class InputService {
       return false;
     }
 
-    // 2. Premium / Predits Limits
-    // Dynamic chat must remain sendable as long as the user has dredits. Predits
-    // are only a routing/cost concern after the server chooses a premium path.
+    // 2. Credit gate
+    //
+    // Billing v2 retired the premium lane and the Dynamic Chat currency: every
+    // model bills its real cost against one balance, so both cases collapse
+    // into "can they afford to start a text request". canUsePremiumModel and
+    // canSendDynamicChat keep the pre-migration behaviour for accounts the
+    // lazy migration has not touched yet.
+    final creditsManager = context.read<CreditsManager>();
+
     if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
-      if ((availablePredits ?? 0) < 10) {
+      if (!creditsManager.canUsePremiumModel) {
         return false;
       }
     }
 
-    // 3. Dynamic Chat / Dredits Limit
     if (isDynamicChatMode) {
-      if ((availableDredits ?? 0) < 1) {
+      if (!creditsManager.canSendDynamicChat) {
         return false;
       }
     }

--- a/lib/chat/services/api.dart
+++ b/lib/chat/services/api.dart
@@ -300,7 +300,7 @@ class ApiService {
             "stream": true,
             if (source != null) "source": source,
             if (tools != null) "tools": tools,
-            "tool_choice": (tools != null) ? "auto" : null,
+            if (tools != null) "tool_choice": "auto",
             "enableReasoning": enablefeatureReasoning,
             "enableWebSearch": enableWebSearch,
             "isCharacterModel": isCharacterModel,
@@ -402,6 +402,13 @@ class ApiService {
                       break;
                     case 'FAL_SCHEMA_INVALID':
                       userMsg = localizations.falErrorSchemaInvalid;
+                      break;
+                    case 'FAL_OFFLINE':
+                      // The server disables the fal lane when the provider
+                      // balance runs low. falOfflineMessage explains that in
+                      // the user's language; without this case it fell
+                      // through to the generic server error.
+                      userMsg = localizations.falOfflineMessage;
                       break;
                     case 'LIMIT_IMAGE_INSUFFICIENT':
                       userMsg = localizations.errorReachedLimit;

--- a/lib/chat/services/speech.dart
+++ b/lib/chat/services/speech.dart
@@ -3,8 +3,22 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:speech_to_text/speech_to_text.dart';
 
+import 'stt_remote.dart';
+
 class SpeechService with ChangeNotifier {
   final SpeechToText _speech = SpeechToText();
+  final RemoteSttService _remote = RemoteSttService.instance;
+
+  /// True while Deepgram is driving. The on-device recogniser stays as the
+  /// fallback for anyone the remote path cannot serve — no balance, no
+  /// network, permission refused — so both engines have to be accounted for
+  /// everywhere below.
+  bool _usingRemote = false;
+
+  /// Deepgram reports each settled span once and then moves on, while the
+  /// text field wants the whole utterance. Finalised spans accumulate here
+  /// and the current interim span is appended for display.
+  String _finalizedText = "";
 
   bool _isAvailable = false;
 
@@ -18,7 +32,7 @@ class SpeechService with ChangeNotifier {
   // Getters
   bool get isListening => _isListening;
 
-  double get soundLevel => _soundLevel;
+  double get soundLevel => _usingRemote ? _remote.soundLevel.value : _soundLevel;
 
   bool get isAvailable => _isAvailable;
 
@@ -98,19 +112,38 @@ class SpeechService with ChangeNotifier {
 
     _localeId = locale;
 
+    // Try Deepgram first. It returns false without starting anything when it
+    // cannot run, so falling through costs nothing.
+    _finalizedText = "";
+    final startedRemote = await _remote.start(
+      onResult: (result) {
+        final spoken = result.isFinal
+            ? _appendFinal(result.text)
+            : _withInterim(result.text);
+        onResult(_capitalize(spoken));
+      },
+      onClosed: () {
+        _usingRemote = false;
+        _isListening = false;
+        notifyListeners();
+      },
+    );
+
+    if (startedRemote) {
+      _usingRemote = true;
+      _isAvailable = true;
+      _isDeviceSupported = true;
+      _isListening = true;
+      _remote.soundLevel.addListener(_onRemoteLevel);
+      notifyListeners();
+      return;
+    }
+
     await _speech.listen(
       localeId: _localeId,
       onResult: (result) {
         // Send partial or final results immediately to the text field
-        String text = result.recognizedWords;
-        // Strict Capitalization: First letter of FIRST word upper, rest lower.
-        if (text.isNotEmpty) {
-          text = text.trim();
-          if (text.isNotEmpty) {
-            text = text[0].toUpperCase() + text.substring(1).toLowerCase();
-          }
-        }
-        onResult(text);
+        onResult(_capitalize(result.recognizedWords));
       },
       onSoundLevelChange: (level) {
         if (!_isListening) return; // Guard against updates after stop
@@ -132,6 +165,33 @@ class SpeechService with ChangeNotifier {
     _isListening = false;
     _soundLevel = 0.0;
     notifyListeners();
+
+    if (_usingRemote) {
+      _usingRemote = false;
+      _remote.soundLevel.removeListener(_onRemoteLevel);
+      await _remote.stop();
+      return;
+    }
     await _speech.stop();
+  }
+
+  void _onRemoteLevel() => notifyListeners();
+
+  /// Adds a settled span to the utterance and returns the whole thing.
+  String _appendFinal(String span) {
+    _finalizedText = _finalizedText.isEmpty ? span : "$_finalizedText $span";
+    return _finalizedText;
+  }
+
+  /// The utterance so far plus the span Deepgram is still revising.
+  String _withInterim(String span) =>
+      _finalizedText.isEmpty ? span : "$_finalizedText $span";
+
+  /// Matches the on-device path: first letter upper, the rest lower, so the
+  /// text field reads the same whichever engine produced it.
+  String _capitalize(String text) {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return trimmed;
+    return trimmed[0].toUpperCase() + trimmed.substring(1).toLowerCase();
   }
 }

--- a/lib/chat/services/stt_remote.dart
+++ b/lib/chat/services/stt_remote.dart
@@ -1,0 +1,277 @@
+// lib/chat/services/stt_remote.dart
+//
+// Deepgram dictation.
+//
+// The microphone streams straight to Deepgram rather than through Fulcrum.
+// Deepgram issues short-lived tokens, so the server only has to mint one and
+// charge for it — the audio itself never touches our infrastructure, which
+// keeps latency to a single hop and the Cloud Function bill to one short call
+// per session.
+//
+// Everything here degrades to false/null rather than throwing. The caller
+// keeps the on-device recogniser as a fallback, so a failure means "use the
+// other engine", not "dictation is broken".
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:record/record.dart';
+
+/// One transcript update. Deepgram sends a running best guess and then a
+/// settled version of the same span; [isFinal] separates them so the caller
+/// can replace rather than append.
+class SttResult {
+  const SttResult(this.text, {required this.isFinal});
+
+  final String text;
+  final bool isFinal;
+}
+
+class RemoteSttService {
+  RemoteSttService._();
+  static final RemoteSttService instance = RemoteSttService._();
+
+  static const String _tokenEndpoint =
+      "https://getspeechtoken-o5h7dmtija-ew.a.run.app";
+
+  // Raw PCM at 16 kHz mono: what Deepgram expects for linear16, and small
+  // enough to stream comfortably on mobile data.
+  static const int _sampleRate = 16000;
+
+  /// `language=multi` selects nova-3 multilingual. Turkish is not covered by
+  /// the cheaper monolingual model, so this is not an optional upgrade.
+  static const String _listenUrl =
+      "wss://api.deepgram.com/v1/listen"
+      "?model=nova-3&language=multi&encoding=linear16"
+      "&sample_rate=$_sampleRate&channels=1"
+      "&interim_results=true&smart_format=true";
+
+  final Dio _dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 15),
+  ));
+
+  AudioRecorder? _recorder;
+  WebSocket? _socket;
+  StreamSubscription<Uint8List>? _micSubscription;
+  bool _closing = false;
+
+  bool get isActive => _socket != null;
+
+  /// Latest microphone loudness, 0..1, derived from the PCM the recorder hands
+  /// us. The on-device recogniser reports this itself; here it has to be
+  /// measured, otherwise the waveform in the UI would sit still.
+  final ValueNotifier<double> soundLevel = ValueNotifier<double>(0.0);
+
+  /// Asks the server for a short-lived Deepgram token. Returns null when
+  /// dictation is unavailable — no session, no balance, provider down.
+  Future<String?> _fetchToken() async {
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) return null;
+      final idToken = await user.getIdToken();
+      if (idToken == null) return null;
+
+      final response = await _dio.post<Map<String, dynamic>>(
+        _tokenEndpoint,
+        data: const <String, dynamic>{},
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $idToken',
+            'Content-Type': 'application/json; charset=UTF-8',
+          },
+          validateStatus: (_) => true,
+        ),
+      );
+
+      if (response.statusCode != 200) {
+        debugPrint("[RemoteStt] Token declined: HTTP ${response.statusCode}");
+        return null;
+      }
+      final token = response.data?['token'];
+      return token is String && token.isNotEmpty ? token : null;
+    } catch (e) {
+      debugPrint("[RemoteStt] Token request failed: $e");
+      return null;
+    }
+  }
+
+  /// Opens the microphone and starts transcribing.
+  ///
+  /// Returns false if the remote path could not be established, in which case
+  /// nothing has been started and the caller should use the on-device engine.
+  Future<bool> start({
+    required void Function(SttResult result) onResult,
+    void Function()? onClosed,
+  }) async {
+    if (_socket != null) return true;
+    _closing = false;
+
+    final recorder = AudioRecorder();
+    try {
+      if (!await recorder.hasPermission()) {
+        debugPrint("[RemoteStt] Microphone permission denied.");
+        await recorder.dispose();
+        return false;
+      }
+    } catch (e) {
+      debugPrint("[RemoteStt] Permission check failed: $e");
+      await recorder.dispose();
+      return false;
+    }
+
+    final token = await _fetchToken();
+    if (token == null) {
+      await recorder.dispose();
+      return false;
+    }
+
+    try {
+      _socket = await WebSocket.connect(
+        _listenUrl,
+        headers: {'Authorization': 'Bearer $token'},
+      ).timeout(const Duration(seconds: 10));
+    } catch (e) {
+      debugPrint("[RemoteStt] Connect failed: $e");
+      await recorder.dispose();
+      _socket = null;
+      return false;
+    }
+
+    _recorder = recorder;
+
+    _socket!.listen(
+      (dynamic message) {
+        if (message is! String) return;
+        final result = _parseTranscript(message);
+        if (result != null) onResult(result);
+      },
+      onError: (Object e) {
+        debugPrint("[RemoteStt] Socket error: $e");
+        unawaited(stop());
+        onClosed?.call();
+      },
+      onDone: () {
+        if (!_closing) onClosed?.call();
+        unawaited(stop());
+      },
+      cancelOnError: true,
+    );
+
+    try {
+      final stream = await recorder.startStream(
+        const RecordConfig(
+          encoder: AudioEncoder.pcm16bits,
+          sampleRate: _sampleRate,
+          numChannels: 1,
+          echoCancel: true,
+          noiseSuppress: true,
+        ),
+      );
+
+      _micSubscription = stream.listen(
+        (chunk) {
+          soundLevel.value = _levelOf(chunk);
+          final socket = _socket;
+          if (socket != null && socket.readyState == WebSocket.open) {
+            socket.add(chunk);
+          }
+        },
+        onError: (Object e) {
+          debugPrint("[RemoteStt] Microphone error: $e");
+          unawaited(stop());
+          onClosed?.call();
+        },
+        cancelOnError: true,
+      );
+    } catch (e) {
+      debugPrint("[RemoteStt] Could not start microphone: $e");
+      await stop();
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Closes the microphone and the socket, asking Deepgram to flush whatever
+  /// it is still holding so the last words are not lost.
+  Future<void> stop() async {
+    _closing = true;
+    soundLevel.value = 0.0;
+
+    await _micSubscription?.cancel();
+    _micSubscription = null;
+
+    try {
+      await _recorder?.stop();
+    } catch (e) {
+      debugPrint("[RemoteStt] Recorder stop failed: $e");
+    }
+    try {
+      await _recorder?.dispose();
+    } catch (_) {}
+    _recorder = null;
+
+    final socket = _socket;
+    _socket = null;
+    if (socket != null) {
+      try {
+        if (socket.readyState == WebSocket.open) {
+          socket.add(jsonEncode({'type': 'CloseStream'}));
+        }
+        await socket.close();
+      } catch (e) {
+        debugPrint("[RemoteStt] Socket close failed: $e");
+      }
+    }
+  }
+
+  /// Deepgram wraps transcripts in a Results envelope; anything else on the
+  /// socket (metadata, keep-alives) is not a transcript.
+  SttResult? _parseTranscript(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return null;
+      if (decoded['type'] != 'Results') return null;
+
+      final alternatives =
+          decoded['channel']?['alternatives'] as List<dynamic>?;
+      if (alternatives == null || alternatives.isEmpty) return null;
+
+      final transcript = alternatives.first?['transcript'];
+      if (transcript is! String || transcript.trim().isEmpty) return null;
+
+      return SttResult(
+        transcript.trim(),
+        isFinal: decoded['is_final'] == true,
+      );
+    } catch (e) {
+      debugPrint("[RemoteStt] Could not parse message: $e");
+      return null;
+    }
+  }
+
+  /// RMS of a little-endian 16-bit PCM chunk, normalised to 0..1 and eased so
+  /// the meter responds the way the on-device one does.
+  double _levelOf(Uint8List chunk) {
+    if (chunk.length < 2) return 0.0;
+    final samples = chunk.buffer.asInt16List(
+      chunk.offsetInBytes,
+      chunk.lengthInBytes ~/ 2,
+    );
+    if (samples.isEmpty) return 0.0;
+
+    var sum = 0.0;
+    for (final sample in samples) {
+      final normalised = sample / 32768.0;
+      sum += normalised * normalised;
+    }
+    final rms = math.sqrt(sum / samples.length);
+    return (rms * 3.0).clamp(0.0, 1.0);
+  }
+}

--- a/lib/chat/services/tts_remote.dart
+++ b/lib/chat/services/tts_remote.dart
@@ -1,0 +1,173 @@
+// lib/chat/services/tts_remote.dart
+//
+// ElevenLabs speech for voice mode, one sentence at a time.
+//
+// Voice mode already splits the model's reply into sentences and speaks them
+// from a queue, so this service is built around that shape: each call carries
+// one sentence and returns finished audio. That keeps the Cloud Function open
+// for a few hundred milliseconds per sentence instead of for the length of the
+// conversation, and it means playback can start on sentence one while the
+// model is still writing sentence three.
+//
+// Every entry point degrades to null rather than throwing. Voice mode must
+// never go silent because the network hiccuped — the caller falls back to the
+// on-device voice.
+
+import 'dart:async';
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+
+class RemoteTtsService {
+  RemoteTtsService._();
+  static final RemoteTtsService instance = RemoteTtsService._();
+
+  static const String _endpoint =
+      "https://synthesizespeech-o5h7dmtija-ew.a.run.app";
+
+  /// Matches TTS_MAX_CHARS in functions/src/voice.js. Sentences longer than
+  /// this are rejected server-side, so they are spoken on-device instead of
+  /// spending a request to find that out.
+  static const int maxChars = 800;
+
+  final Dio _dio = Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 30),
+  ));
+
+  AudioPlayer? _player;
+  bool _contextConfigured = false;
+
+  /// The audio session voice mode needs. flutter_tts configures this itself,
+  /// so playing through audioplayers instead means configuring it here too —
+  /// otherwise iOS routes playback to the earpiece and the microphone drops
+  /// out mid-conversation.
+  static final AudioContext _voiceContext = AudioContext(
+    iOS: AudioContextIOS(
+      category: AVAudioSessionCategory.playAndRecord,
+      options: const {
+        AVAudioSessionOptions.allowBluetooth,
+        AVAudioSessionOptions.allowBluetoothA2DP,
+        AVAudioSessionOptions.mixWithOthers,
+        AVAudioSessionOptions.defaultToSpeaker,
+      },
+    ),
+    android: AudioContextAndroid(
+      isSpeakerphoneOn: true,
+      stayAwake: true,
+      contentType: AndroidContentType.speech,
+      usageType: AndroidUsageType.assistant,
+      audioFocus: AndroidAudioFocus.gainTransientMayDuck,
+    ),
+  );
+
+  Future<AudioPlayer> _ensurePlayer() async {
+    if (!_contextConfigured) {
+      try {
+        await AudioPlayer.global.setAudioContext(_voiceContext);
+        _contextConfigured = true;
+      } catch (e) {
+        debugPrint("[RemoteTts] Could not set audio context: $e");
+      }
+    }
+    return _player ??= AudioPlayer();
+  }
+
+  /// Fetches spoken audio for one sentence.
+  ///
+  /// Returns null when speech is unavailable for any reason — no session, no
+  /// balance, provider down — so the caller can fall back rather than stall.
+  Future<Uint8List?> synthesize(String text, {String? voiceId}) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty || trimmed.length > maxChars) return null;
+
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) return null;
+      final token = await user.getIdToken();
+      if (token == null) return null;
+
+      final response = await _dio.post<List<int>>(
+        _endpoint,
+        data: {
+          'text': trimmed,
+          if (voiceId != null && voiceId.isNotEmpty) 'voiceId': voiceId,
+        },
+        options: Options(
+          responseType: ResponseType.bytes,
+          headers: {
+            'Authorization': 'Bearer $token',
+            'Content-Type': 'application/json; charset=UTF-8',
+          },
+          // Handled below so a 402 does not surface as an exception.
+          validateStatus: (_) => true,
+        ),
+      );
+
+      if (response.statusCode != 200 || response.data == null) {
+        debugPrint("[RemoteTts] Declined: HTTP ${response.statusCode}");
+        return null;
+      }
+      final bytes = Uint8List.fromList(response.data!);
+      return bytes.isEmpty ? null : bytes;
+    } catch (e) {
+      debugPrint("[RemoteTts] synthesize failed: $e");
+      return null;
+    }
+  }
+
+  /// Plays finished audio and returns when it has stopped.
+  ///
+  /// Returns false if playback could not start, so the caller can speak the
+  /// same sentence on-device instead of skipping it.
+  Future<bool> play(Uint8List bytes) async {
+    try {
+      final player = await _ensurePlayer();
+      await player.stop();
+      await player.play(BytesSource(bytes));
+
+      // onPlayerComplete does not fire if playback is stopped from elsewhere,
+      // so the state stream is watched as well.
+      final completer = Completer<void>();
+      late final StreamSubscription<void> onComplete;
+      late final StreamSubscription<PlayerState> onState;
+
+      void finish() {
+        if (!completer.isCompleted) completer.complete();
+      }
+
+      onComplete = player.onPlayerComplete.listen((_) => finish());
+      onState = player.onPlayerStateChanged.listen((state) {
+        if (state == PlayerState.stopped || state == PlayerState.completed) {
+          finish();
+        }
+      });
+
+      await completer.future;
+      await onComplete.cancel();
+      await onState.cancel();
+      return true;
+    } catch (e) {
+      debugPrint("[RemoteTts] play failed: $e");
+      return false;
+    }
+  }
+
+  /// Cuts playback short — used when the user interrupts.
+  Future<void> stop() async {
+    try {
+      await _player?.stop();
+    } catch (e) {
+      debugPrint("[RemoteTts] stop failed: $e");
+    }
+  }
+
+  Future<void> dispose() async {
+    try {
+      await _player?.dispose();
+    } catch (_) {}
+    _player = null;
+  }
+}

--- a/lib/chat/services/voice.dart
+++ b/lib/chat/services/voice.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 import 'package:provider/provider.dart';
 import 'package:cortex/chat/services/speech.dart';
+import 'package:cortex/chat/services/tts_remote.dart';
 
 enum VoiceState {
   listening,
@@ -49,6 +50,21 @@ class VoiceService with ChangeNotifier {
   // Queue for TTS to speak text as it streams in from AI
   final List<String> _sentenceQueue = [];
   bool _isSpeaking = false;
+
+  final RemoteTtsService _remoteTts = RemoteTtsService.instance;
+
+  /// Bumped whenever speech is cancelled. Remote audio is fetched over the
+  /// network, so a sentence can still be in flight when the user interrupts;
+  /// without this the reply they cut off would play a moment later.
+  int _speechGeneration = 0;
+
+  /// Abandons anything queued or in flight. Callers that clear the queue must
+  /// go through here, otherwise an already-dispatched request still speaks.
+  void _cancelPendingSpeech() {
+    _speechGeneration++;
+    _sentenceQueue.clear();
+    unawaited(_remoteTts.stop());
+  }
   final StringBuffer _incomingTextBuffer = StringBuffer();
   final StringBuffer _fullAiResponseBuffer =
       StringBuffer(); // Accumulates full response for Flow Loop
@@ -194,7 +210,7 @@ class VoiceService with ChangeNotifier {
         "[VoiceService] Interrupting Flow. Transitioning to Listen Mode.");
     _isFlowInterrupted = true;
     _isSpeaking = false;
-    _sentenceQueue.clear();
+    _cancelPendingSpeech();
     _incomingTextBuffer.clear();
 
     // [FIX] Ensure TTS is completely stopped
@@ -212,8 +228,9 @@ class VoiceService with ChangeNotifier {
 
   void stopSpeaking({BuildContext? context}) async {
     await _flutterTts.stop();
+    await _remoteTts.stop();
     _isSpeaking = false;
-    _sentenceQueue.clear();
+    _cancelPendingSpeech();
     _incomingTextBuffer.clear();
 
     // [FIX] Hard Stop: Breaking the Flow Loop entirely on manual stop.
@@ -300,7 +317,7 @@ class VoiceService with ChangeNotifier {
     _voiceSystemPrompt = voiceSystemPrompt;
     _isSpeaking = false;
     _liveTranscript = "";
-    _sentenceQueue.clear();
+    _cancelPendingSpeech();
     _incomingTextBuffer.clear();
     _fullAiResponseBuffer.clear();
 
@@ -359,7 +376,7 @@ class VoiceService with ChangeNotifier {
     // User might resume session, but flow state is persistent until toggled off?
     // Assuming stopSession completely stops everything.
     isFlowActive = false;
-    _sentenceQueue.clear();
+    _cancelPendingSpeech();
     _incomingTextBuffer.clear();
     _fullAiResponseBuffer.clear();
     _isSpeaking = false;
@@ -588,6 +605,11 @@ class VoiceService with ChangeNotifier {
       return;
     }
 
+    // The next sentence's audio is fetched while the current one plays, so the
+    // gap between sentences is playback-to-playback rather than a network
+    // round trip each time.
+    Future<Uint8List?>? prefetched;
+
     // Safety Loop
     while (_sentenceQueue.isNotEmpty) {
       // Check if interrupted?
@@ -596,12 +618,34 @@ class VoiceService with ChangeNotifier {
 
       _isSpeaking = true;
       _updateState(VoiceState.speaking);
-      String next = _sentenceQueue.removeAt(0);
+      final int generation = _speechGeneration;
+      final String next = _sentenceQueue.removeAt(0);
 
       debugPrint("[VoiceService] Speaking: $next");
-      await _flutterTts.speak(next);
-      // await _flutterTts.speak() waits because we set awaitSpeakCompletion(true)
-      // So this line blocks until speech is done.
+
+      final Future<Uint8List?> pending =
+          prefetched ?? _remoteTts.synthesize(next);
+      prefetched = _sentenceQueue.isEmpty
+          ? null
+          : _remoteTts.synthesize(_sentenceQueue.first);
+
+      final Uint8List? audio = await pending;
+      if (generation != _speechGeneration) return;
+
+      // A null result means speech was unavailable — no balance, provider
+      // down, no session. Voice mode falls back to the on-device voice rather
+      // than going silent.
+      bool spoken = false;
+      if (audio != null) {
+        spoken = await _remoteTts.play(audio);
+      }
+      if (generation != _speechGeneration) return;
+      if (!spoken) {
+        await _flutterTts.speak(next);
+        // await _flutterTts.speak() waits because we set awaitSpeakCompletion(true)
+        // So this line blocks until speech is done.
+        if (generation != _speechGeneration) return;
+      }
 
       _isSpeaking = false;
     }

--- a/lib/server/credits.dart
+++ b/lib/server/credits.dart
@@ -25,6 +25,41 @@ class CreditsManager {
   final ValueNotifier<int?> preditsNotifier = ValueNotifier<int?>(null);
   final ValueNotifier<int?> dreditsNotifier = ValueNotifier<int?>(null);
 
+  /// Whether this account has been migrated to the single-credit billing
+  /// engine. Migration is lazy and per-user, so both systems are live at once
+  /// and every gate has to ask which one it is looking at.
+  final ValueNotifier<bool> billingV2Notifier = ValueNotifier<bool>(false);
+
+  /// What the user can actually spend: the allowance bucket plus owned
+  /// credits. This is the number the server gates on, so the client gates on
+  /// the same one instead of guessing from a display total.
+  final ValueNotifier<int?> spendableNotifier = ValueNotifier<int?>(null);
+
+  /// Mirrors MIN_TEXT_BALANCE in functions/src/billing.js. Below this the
+  /// server refuses to start a text request, so offering it would just produce
+  /// a failure the user cannot act on.
+  static const int minTextBalance = 50;
+
+  /// Under billing v2 there is no premium lane — every model bills its real
+  /// cost, so anything the user can afford is allowed and this is the only
+  /// question worth asking. Before migration it falls back to the predit
+  /// balance the old engine maintained.
+  bool get canUsePremiumModel {
+    if (billingV2Notifier.value) {
+      return (spendableNotifier.value ?? 0) >= minTextBalance;
+    }
+    return (preditsNotifier.value ?? 0) > 0;
+  }
+
+  /// Dynamic Chat had its own currency (dredits) under the old engine. v2
+  /// retires it: a dynamic turn is billed like any other text turn.
+  bool get canSendDynamicChat {
+    if (billingV2Notifier.value) {
+      return (spendableNotifier.value ?? 0) >= minTextBalance;
+    }
+    return (dreditsNotifier.value ?? 0) >= 1;
+  }
+
   // --- Internal State ---
   StreamSubscription? _creditsSubscription;
   String? _activeUid;
@@ -34,6 +69,19 @@ class CreditsManager {
     if (value is int) return value;
     if (value is num) return value.toInt();
     if (value is String) return int.tryParse(value) ?? fallback;
+    return fallback;
+  }
+
+  /// Allowance balances are fractional on the server (credits accrue by the
+  /// millisecond), so they arrive as doubles and have to be floored rather
+  /// than parsed as ints.
+  int _readFloor(dynamic value, int fallback) {
+    if (value is int) return value;
+    if (value is num) return value.floor();
+    if (value is String) {
+      final parsed = double.tryParse(value);
+      return parsed == null ? fallback : parsed.floor();
+    }
     return fallback;
   }
 
@@ -57,6 +105,8 @@ class CreditsManager {
       totalCreditsNotifier.value = 0; // User logged out, set to 0
       preditsNotifier.value = 0;
       dreditsNotifier.value = 0;
+      spendableNotifier.value = 0;
+      billingV2Notifier.value = false;
       return;
     }
 
@@ -67,6 +117,7 @@ class CreditsManager {
     totalCreditsNotifier.value = null;
     preditsNotifier.value = null;
     dreditsNotifier.value = null;
+    spendableNotifier.value = null;
 
     // Listen to the user's document for real-time changes.
     _creditsSubscription = FirebaseFirestore.instance
@@ -81,24 +132,45 @@ class CreditsManager {
 
       if (snapshot.exists) {
         final data = snapshot.data() ?? {};
+        final billingV2 = data['billingV2'] == true;
         final main = _readInt(data['credits'], 0);
-        final bonus = _readInt(data['bonusCredits'], 0);
-        final predits = _readInt(data['predits'], 100);
-        final dredits = _readInt(data['dredits'], 100);
+        billingV2Notifier.value = billingV2;
 
-        // Notify listeners with the new total.
-        totalCreditsNotifier.value = main + bonus;
-        preditsNotifier.value = predits;
-        dreditsNotifier.value = dredits;
+        if (billingV2) {
+          // One currency. Spendable is the allowance bucket plus owned
+          // credits — exactly what authorizeRequest checks server-side.
+          // predits/dredits still arrive as legacy mirrors for older clients;
+          // they are ignored here in favour of the fields they mirror.
+          final allowance = _readFloor(data['allowBalance'], 0);
+          final spendable = allowance + main;
 
-        debugPrint(
-            "Balances updated: Credits=${totalCreditsNotifier.value}, Predits=${preditsNotifier.value}, Dredits=${dreditsNotifier.value}");
+          totalCreditsNotifier.value = spendable;
+          spendableNotifier.value = spendable;
+          preditsNotifier.value = spendable;
+          dreditsNotifier.value = spendable;
+
+          debugPrint(
+              "Balances updated (v2): Spendable=$spendable (allowance=$allowance, owned=$main)");
+        } else {
+          final bonus = _readInt(data['bonusCredits'], 0);
+          final predits = _readInt(data['predits'], 100);
+          final dredits = _readInt(data['dredits'], 100);
+
+          totalCreditsNotifier.value = main + bonus;
+          spendableNotifier.value = main + bonus;
+          preditsNotifier.value = predits;
+          dreditsNotifier.value = dredits;
+
+          debugPrint(
+              "Balances updated: Credits=${totalCreditsNotifier.value}, Predits=${preditsNotifier.value}, Dredits=${dreditsNotifier.value}");
+        }
       } else {
         // User document doesn't exist yet, so they have 0 credits.
         debugPrint("CreditsManager: User document does not exist for $uid.");
         totalCreditsNotifier.value = 0;
         preditsNotifier.value = 0;
         dreditsNotifier.value = 0;
+        spendableNotifier.value = 0;
       }
     }, onError: (error) {
       if (_isStaleListener(generation, uid)) {
@@ -111,6 +183,7 @@ class CreditsManager {
       totalCreditsNotifier.value = 0;
       preditsNotifier.value = 0;
       dreditsNotifier.value = 0;
+      spendableNotifier.value = 0;
     });
   }
 
@@ -123,5 +196,7 @@ class CreditsManager {
     totalCreditsNotifier.value = null; // Reset to null on dispose
     preditsNotifier.value = null;
     dreditsNotifier.value = null;
+    spendableNotifier.value = null;
+    billingV2Notifier.value = false;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1081,18 +1081,18 @@ packages:
     dependency: "direct main"
     description:
       name: in_app_purchase
-      sha256: "5cddd7f463f3bddb1d37a72b95066e840d5822d66291331d7f8f05ce32c24b6c"
+      sha256: "0e9510b80b0074e89ab0a8e0fc901439b779dc9ae575ab8d419253c6e1627716"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.3.0"
   in_app_purchase_android:
     dependency: "direct main"
     description:
       name: in_app_purchase_android
-      sha256: "634bee4734b17fe55f370f0ac07a22431a9666e0f3a870c6d20350856e8bbf71"
+      sha256: f7327b5fd70d8dc1b419fb4cd5c17520175c4059441afd985e8a9c3fa2cefed9
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0+10"
+    version: "0.5.3"
   in_app_purchase_platform_interface:
     dependency: transitive
     description:
@@ -1105,10 +1105,10 @@ packages:
     dependency: "direct main"
     description:
       name: in_app_purchase_storekit
-      sha256: "1d512809edd9f12ff88fce4596a13a18134e2499013f4d6a8894b04699363c93"
+      sha256: "66aa6db2236aed23d1b0dd508fb33641ed9878d5e5fb6db5fdbd690b7de6fe98"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.8+1"
+    version: "0.4.11+2"
   in_app_review:
     dependency: "direct main"
     description:
@@ -1217,18 +1217,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   math_expressions:
     dependency: "direct main"
     description:
@@ -1241,10 +1241,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: "direct main"
     description:
@@ -1525,6 +1525,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  record:
+    dependency: "direct main"
+    description:
+      name: record
+      sha256: "82539d1372e23cf51375fdfcba084f39912bcbf9a953b75d56596691f8f11c0f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.1"
+  record_android:
+    dependency: transitive
+    description:
+      name: record_android
+      sha256: "28f1108626a190e249b01ffa9f639070e31e5157474b64a5ae380bf36aec9559"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  record_ios:
+    dependency: transitive
+    description:
+      name: record_ios
+      sha256: "21d189f49a598af4697dac4cc9e48389ac0a1fb3e916622b5504a58d9b96313e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  record_linux:
+    dependency: transitive
+    description:
+      name: record_linux
+      sha256: b7484fdaf1f6d291543b9cf615e78096662b02df68d7a4728b13f352bde58d27
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      sha256: ced7495abf3d683e8a7dbe8fc96df8ea5722837a26f922b7cb7c5de11661bb46
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  record_platform_interface:
+    dependency: transitive
+    description:
+      name: record_platform_interface
+      sha256: d94b37cadb8fe203e64b0e9893271c0b71b34f2550ee7fb0c6105d650e00c1f5
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   record_use:
     dependency: transitive
     description:
@@ -1533,6 +1581,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  record_web:
+    dependency: transitive
+    description:
+      name: record_web
+      sha256: f53d3da48de3618a331868aec73261d5a75eddd9c09409afd9ec6d66b25db532
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  record_windows:
+    dependency: transitive
+    description:
+      name: record_windows
+      sha256: e6884f91be4370f122111aca3c04291ae5fe6d8fd045f87afa967635a02dbbac
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   retry:
     dependency: "direct main"
     description:
@@ -1790,10 +1854,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   timezone:
     dependency: "direct main"
     description:
@@ -2099,5 +2163,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,6 +105,7 @@ dependencies:
   universal_io: ^2.3.1
   audioplayers: ^6.6.0
   video_player: ^2.9.2
+  record: ^7.1.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+811
+version: 8.1.1+812
 environment:
   sdk: '>=3.4.3 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+812
+version: 8.1.1+813
 environment:
   sdk: '>=3.4.3 <4.0.0'
 


### PR DESCRIPTION
Four changes going into 8.1.1. The version **name** stays 8.1.1; only the versionCode advances (813).

## 1 · Dictation through Deepgram

Dictation ran on whatever recogniser the OS provided — it varies by device and is missing entirely on some Android builds. Deepgram nova-3 is now the primary engine.

The microphone streams **straight to Deepgram**, not through Fulcrum. Deepgram is the one provider here that issues short-lived tokens, so the server only mints one and charges for it; audio never touches our infrastructure. That keeps latency to a single hop and the function bill to one short call per session.

`SpeechService` keeps its public API, so `buttons.dart` and `voice.dart` are untouched: it tries Deepgram, and `start()` returns `false` **without having started anything** when it cannot run, so falling through to `speech_to_text` costs nothing. No balance, no network, permission refused — all land on the device engine rather than a dead microphone.

The wrapper absorbs two differences. Deepgram reports each settled span once and moves on, while the text field wants the whole utterance, so finalised spans accumulate and the interim span is appended for display. And it reports no sound level, so amplitude is measured from the PCM the recorder hands us — otherwise the waveform in the UI would sit still.

`language=multi` selects nova-3 multilingual. Turkish is not covered by the cheaper monolingual model, so that is not an optional upgrade.

Adds `record ^7.1.1` for raw PCM — `speech_to_text` only yields text, never audio. `RECORD_AUDIO` and `NSMicrophoneUsageDescription` were already declared.

## 2 · Speech through ElevenLabs

Voice mode already split the reply into sentences and spoke them from a queue, so remote speech drops into **the one line that spoke each sentence**. Everything around it — sentence splitting, the queue, the state machine — is unchanged.

Each sentence is its own short request, so the function stays warm for a few hundred milliseconds per sentence rather than for the whole conversation. The next sentence's audio is fetched while the current one plays, so the gap between sentences is playback-to-playback rather than a network round trip each time.

Two things the queue did not need before and does now:

- **A generation counter.** Remote audio arrives over the network, so a sentence can still be in flight when the user interrupts; without this the reply they cut off would play a moment later. Every path that cleared the queue now goes through `_cancelPendingSpeech`.
- **An audio session.** `flutter_tts` configured iOS itself; playing through `audioplayers` means setting `playAndRecord` + `defaultToSpeaker` here, or iOS routes playback to the earpiece and drops the microphone mid-conversation.

`synthesize()` and `play()` return null/false rather than throwing, and the caller speaks the sentence on-device instead. Voice mode must not go silent because the network hiccuped.

The speaking voice is left to the server, which falls back to `server/voice.defaultVoiceId` — voices can then change without an app update.

## 3 · Billing v2 client

The server is moving to one currency: 1 credit = $0.001 of real spend, no premium lane, predits and dredits retired. Migration is lazy and per-user, so both engines are live at once and the client has to know which one it is looking at.

`CreditsManager` reads `billingV2` and derives spendable from `allowBalance + credits` — the same sum `authorizeRequest` gates on server-side. Allowance accrues by the millisecond and arrives fractional, so it is floored rather than parsed as an int.

The four credit gates asked two questions v2 cannot answer: "does this user have predits for a premium model" and "does this user have a dredit for Dynamic Chat". Both collapse into "can they afford to start a text request". The threshold mirrors `MIN_TEXT_BALANCE` (50) so the client stops offering what the server is about to refuse. Accounts migration has not reached keep the old behaviour.

## 4 · Two bug fixes

**`tool_choice`** went out on every request, as `null` when no tools were attached. The server spreads the body into its payload and only overwrites `tool_choice` inside the tools branch, so the null reached the provider. OpenRouter tolerates it; Groq rejects the whole request — which is why **the Groq fallback has never actually caught an OpenRouter failure.** Fixed server-side too (Fulcrum #6), since clients sending the null are already shipped.

**`FAL_OFFLINE`** had no case in the error switch and fell through to the generic server error. The server emits it when the fal provider balance runs low and the lane is disabled, and `falOfflineMessage` already exists in every locale to explain exactly that. The string was written and translated but unreachable.

## Verification

The whole project is clean under `dart analyze` — zero errors. The seven remaining infos are pre-existing deprecations in files this PR does not touch.

The `tool_choice` fix was verified against all three body shapes the client can produce.

## Not tested

**Deepgram has not been exercised on a device.** The code compiles and analyses clean, but streaming raw PCM over a WebSocket carries things only a real microphone can settle: whether Deepgram accepts the format, whether recording and playback conflict on iOS, the timing of the permission prompt. This should be tried on hardware before merging.

The voice features also need `DEEPGRAM_API_KEY`, `ELEVENLABS_API_KEY` and `server/voice.defaultVoiceId`. Without them the app falls back to the on-device engines silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
