### PR TITLE
feat(voice): let the user choose which voice Cortex speaks with

### DIFF
--- a/lib/chat/services/tts_remote.dart
+++ b/lib/chat/services/tts_remote.dart
@@ -40,6 +40,11 @@ class RemoteTtsService {
   AudioPlayer? _player;
   bool _contextConfigured = false;
 
+  /// The voice the user picked, kept here so voice mode does not have to reach
+  /// for a provider on every sentence. VoiceCatalogProvider writes it; null
+  /// means the server picks.
+  String? activeVoiceId;
+
   /// The audio session voice mode needs. flutter_tts configures this itself,
   /// so playing through audioplayers instead means configuring it here too —
   /// otherwise iOS routes playback to the earpiece and the microphone drops
@@ -83,6 +88,10 @@ class RemoteTtsService {
     final trimmed = text.trim();
     if (trimmed.isEmpty || trimmed.length > maxChars) return null;
 
+    // An explicit id wins so the settings preview can audition a voice the
+    // user has not committed to yet.
+    final voice = voiceId ?? activeVoiceId;
+
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) return null;
@@ -93,7 +102,7 @@ class RemoteTtsService {
         _endpoint,
         data: {
           'text': trimmed,
-          if (voiceId != null && voiceId.isNotEmpty) 'voiceId': voiceId,
+          if (voice != null && voice.isNotEmpty) 'voiceId': voice,
         },
         options: Options(
           responseType: ResponseType.bytes,

--- a/lib/chat/services/voice_catalog.dart
+++ b/lib/chat/services/voice_catalog.dart
@@ -1,0 +1,174 @@
+// lib/chat/services/voice_catalog.dart
+//
+// The set of voices Cortex can speak with, and which one this user picked.
+//
+// The list lives in Firestore (`server/voice`) rather than in the app, so
+// voices can be added, reordered or replaced without shipping a release. The
+// choice itself is local — it is a preference, not account state, and it should
+// survive being offline.
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'tts_remote.dart';
+
+/// One selectable voice, as published in `server/voice.voices`.
+class CortexVoice {
+  const CortexVoice({required this.id, required this.name, this.description});
+
+  final String id;
+  final String name;
+
+  /// Optional one-line character note ("warm, conversational"), shown under the
+  /// name so the list is scannable without playing every sample.
+  final String? description;
+
+  static CortexVoice? fromMap(dynamic raw) {
+    if (raw is! Map) return null;
+    final id = raw['id'];
+    final name = raw['name'];
+    if (id is! String || id.trim().isEmpty) return null;
+    return CortexVoice(
+      id: id.trim(),
+      name: name is String && name.trim().isNotEmpty ? name.trim() : id.trim(),
+      description: raw['description'] is String && (raw['description'] as String).trim().isNotEmpty
+          ? (raw['description'] as String).trim()
+          : null,
+    );
+  }
+}
+
+class VoiceCatalogProvider extends ChangeNotifier {
+  static const String _prefsKey = 'selected_voice_id';
+
+  List<CortexVoice> _voices = const [];
+  String? _defaultVoiceId;
+  String? _selectedVoiceId;
+  bool _isLoading = false;
+  bool _hasLoaded = false;
+
+  List<CortexVoice> get voices => _voices;
+  bool get isLoading => _isLoading;
+  bool get hasLoaded => _hasLoaded;
+
+  /// Null until the user picks one, which is the signal to let the server
+  /// decide. The distinction matters: "no choice" should follow the published
+  /// default as it changes, rather than pinning whatever it happened to be.
+  String? get selectedVoiceId => _selectedVoiceId;
+
+  /// What to send with a synthesis request. Null means "server decides".
+  String? get effectiveVoiceId => _selectedVoiceId ?? _defaultVoiceId;
+
+  CortexVoice? get selectedVoice {
+    final id = effectiveVoiceId;
+    if (id == null) return null;
+    for (final voice in _voices) {
+      if (voice.id == id) return voice;
+    }
+    return null;
+  }
+
+  /// Reads the stored choice, then the published list. The choice is read first
+  /// so a slow or failed catalog fetch does not make the settings row look
+  /// unset to someone who has already chosen.
+  Future<void> load({bool force = false}) async {
+    if (_isLoading) return;
+    if (_hasLoaded && !force) return;
+
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final stored = prefs.getString(_prefsKey);
+      if (stored != null && stored.trim().isNotEmpty) {
+        _selectedVoiceId = stored.trim();
+      }
+    } catch (e) {
+      debugPrint("[VoiceCatalog] Could not read stored voice: $e");
+    }
+
+    try {
+      final snapshot = await FirebaseFirestore.instance
+          .collection('server')
+          .doc('voice')
+          .get();
+
+      final data = snapshot.data();
+      if (data != null) {
+        final rawDefault = data['defaultVoiceId'];
+        _defaultVoiceId = rawDefault is String && rawDefault.trim().isNotEmpty
+            ? rawDefault.trim()
+            : null;
+
+        final rawList = data['voices'];
+        if (rawList is List) {
+          _voices = rawList
+              .map(CortexVoice.fromMap)
+              .whereType<CortexVoice>()
+              .toList(growable: false);
+        }
+      }
+      _hasLoaded = true;
+    } catch (e) {
+      // An empty catalog is a working state: the picker hides itself and the
+      // server falls back to its default.
+      debugPrint("[VoiceCatalog] Could not load voices: $e");
+    }
+
+    // A voice can be retired between releases. Drop a stale selection rather
+    // than sending an id the provider will reject.
+    if (_selectedVoiceId != null &&
+        _voices.isNotEmpty &&
+        !_voices.any((v) => v.id == _selectedVoiceId)) {
+      debugPrint("[VoiceCatalog] Stored voice is no longer published; clearing.");
+      _selectedVoiceId = null;
+      unawaitedClear();
+    }
+
+    _publish();
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  /// Voice mode reads the id off the TTS service rather than this provider, so
+  /// every change has to be pushed there.
+  void _publish() {
+    RemoteTtsService.instance.activeVoiceId = effectiveVoiceId;
+  }
+
+  Future<void> select(String voiceId) async {
+    final trimmed = voiceId.trim();
+    if (trimmed.isEmpty || trimmed == _selectedVoiceId) return;
+
+    _selectedVoiceId = trimmed;
+    _publish();
+    notifyListeners();
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_prefsKey, trimmed);
+    } catch (e) {
+      debugPrint("[VoiceCatalog] Could not persist voice: $e");
+    }
+  }
+
+  /// Returns to whatever the server publishes as the default.
+  Future<void> clearSelection() async {
+    if (_selectedVoiceId == null) return;
+    _selectedVoiceId = null;
+    _publish();
+    notifyListeners();
+    await unawaitedClear();
+  }
+
+  Future<void> unawaitedClear() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_prefsKey);
+    } catch (e) {
+      debugPrint("[VoiceCatalog] Could not clear stored voice: $e");
+    }
+  }
+}

--- a/lib/chat/services/voice_catalog.dart
+++ b/lib/chat/services/voice_catalog.dart
@@ -14,11 +14,21 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'tts_remote.dart';
 
 /// One selectable voice, as published in `server/voice.voices`.
+/// How a voice is grouped in the picker. Anything the catalog does not label
+/// falls into [unspecified] and is listed last rather than guessed at.
+enum VoiceGender { male, female, unspecified }
+
 class CortexVoice {
-  const CortexVoice({required this.id, required this.name, this.description});
+  const CortexVoice({
+    required this.id,
+    required this.name,
+    this.description,
+    this.gender = VoiceGender.unspecified,
+  });
 
   final String id;
   final String name;
+  final VoiceGender gender;
 
   /// Optional one-line character note ("warm, conversational"), shown under the
   /// name so the list is scannable without playing every sample.
@@ -32,10 +42,23 @@ class CortexVoice {
     return CortexVoice(
       id: id.trim(),
       name: name is String && name.trim().isNotEmpty ? name.trim() : id.trim(),
+      gender: _genderFrom(raw['gender']),
       description: raw['description'] is String && (raw['description'] as String).trim().isNotEmpty
           ? (raw['description'] as String).trim()
           : null,
     );
+  }
+
+  static VoiceGender _genderFrom(dynamic raw) {
+    if (raw is! String) return VoiceGender.unspecified;
+    switch (raw.trim().toLowerCase()) {
+      case 'male':
+        return VoiceGender.male;
+      case 'female':
+        return VoiceGender.female;
+      default:
+        return VoiceGender.unspecified;
+    }
   }
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -924,5 +924,17 @@
   "categoryPhoto": "Photo",
   "categoryMasculine": "Masculine",
   "categoryFeminine": "Feminine",
-  "categoryInanimate": "Inanimate"
+  "categoryInanimate": "Inanimate",
+  "voiceSelection": "AI Voice",
+  "@voiceSelection": { "description": "Voice picker in settings" },
+  "voiceSelectionDescription": "Choose the voice Cortex speaks with in voice mode.",
+  "@voiceSelectionDescription": { "description": "Voice picker in settings" },
+  "voiceDefaultOption": "Default",
+  "@voiceDefaultOption": { "description": "Voice picker in settings" },
+  "voicePreview": "Play sample",
+  "@voicePreview": { "description": "Voice picker in settings" },
+  "voicePreviewText": "Hello, I am Cortex. How can I help you today?",
+  "@voicePreviewText": { "description": "Voice picker in settings" },
+  "voicePreviewFailed": "Could not play the sample. Check your connection or balance.",
+  "@voicePreviewFailed": { "description": "Voice picker in settings" }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -936,5 +936,9 @@
   "voicePreviewText": "Hello, I am Cortex. How can I help you today?",
   "@voicePreviewText": { "description": "Voice picker in settings" },
   "voicePreviewFailed": "Could not play the sample. Check your connection or balance.",
-  "@voicePreviewFailed": { "description": "Voice picker in settings" }
+  "@voicePreviewFailed": { "description": "Voice picker in settings" },
+  "voiceMale": "Male voices",
+  "@voiceMale": { "description": "Voice picker group heading" },
+  "voiceFemale": "Female voices",
+  "@voiceFemale": { "description": "Voice picker group heading" }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3884,6 +3884,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Inanimate'**
   String get categoryInanimate;
+
+  /// Voice picker in settings
+  ///
+  /// In en, this message translates to:
+  /// **'AI Voice'**
+  String get voiceSelection;
+
+  /// Voice picker in settings
+  ///
+  /// In en, this message translates to:
+  /// **'Choose the voice Cortex speaks with in voice mode.'**
+  String get voiceSelectionDescription;
+
+  /// Voice picker in settings
+  ///
+  /// In en, this message translates to:
+  /// **'Default'**
+  String get voiceDefaultOption;
+
+  /// Voice picker in settings
+  ///
+  /// In en, this message translates to:
+  /// **'Play sample'**
+  String get voicePreview;
+
+  /// Voice picker in settings
+  ///
+  /// In en, this message translates to:
+  /// **'Hello, I am Cortex. How can I help you today?'**
+  String get voicePreviewText;
+
+  /// Voice picker in settings
+  ///
+  /// In en, this message translates to:
+  /// **'Could not play the sample. Check your connection or balance.'**
+  String get voicePreviewFailed;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3920,6 +3920,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not play the sample. Check your connection or balance.'**
   String get voicePreviewFailed;
+
+  /// Voice picker group heading
+  ///
+  /// In en, this message translates to:
+  /// **'Male voices'**
+  String get voiceMale;
+
+  /// Voice picker group heading
+  ///
+  /// In en, this message translates to:
+  /// **'Female voices'**
+  String get voiceFemale;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2106,4 +2106,25 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2127,4 +2127,10 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_az.dart
+++ b/lib/l10n/app_localizations_az.dart
@@ -2145,4 +2145,10 @@ class AppLocalizationsAz extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_az.dart
+++ b/lib/l10n/app_localizations_az.dart
@@ -2124,4 +2124,25 @@ class AppLocalizationsAz extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Cansız';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2116,4 +2116,25 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Neživý';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2137,4 +2137,10 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2164,4 +2164,10 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2143,4 +2143,25 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2136,4 +2136,10 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2115,4 +2115,25 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2165,4 +2165,10 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2144,4 +2144,25 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2150,4 +2150,25 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2171,4 +2171,10 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2138,4 +2138,10 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2117,4 +2117,25 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2149,4 +2149,10 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2128,4 +2128,25 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Élettelen';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2128,4 +2128,25 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2149,4 +2149,10 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2134,4 +2134,25 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2155,4 +2155,10 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2087,4 +2087,10 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2066,4 +2066,25 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2091,4 +2091,10 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2070,4 +2070,25 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2155,4 +2155,10 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2134,4 +2134,25 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_no.dart
+++ b/lib/l10n/app_localizations_no.dart
@@ -2114,4 +2114,25 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Leveløst';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_no.dart
+++ b/lib/l10n/app_localizations_no.dart
@@ -2135,4 +2135,10 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2133,4 +2133,25 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2154,4 +2154,10 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2130,4 +2130,25 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2151,4 +2151,10 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2120,4 +2120,25 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Livlös';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2141,4 +2141,10 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2118,4 +2118,25 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Cansız';
+
+  @override
+  String get voiceSelection => 'Yapay Zeka Sesi';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Cortex’in sesli sohbette kullanacağı sesi seçin.';
+
+  @override
+  String get voiceDefaultOption => 'Varsayılan';
+
+  @override
+  String get voicePreview => 'Örnek dinle';
+
+  @override
+  String get voicePreviewText =>
+      'Merhaba, ben Cortex. Bugün sana nasıl yardımcı olabilirim?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Örnek çalınamadı. Bağlantını veya bakiyeni kontrol et.';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2139,4 +2139,10 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Örnek çalınamadı. Bağlantını veya bakiyeni kontrol et.';
+
+  @override
+  String get voiceMale => 'Erkek sesleri';
+
+  @override
+  String get voiceFemale => 'Kadın sesleri';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2032,4 +2032,10 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get voicePreviewFailed =>
       'Could not play the sample. Check your connection or balance.';
+
+  @override
+  String get voiceMale => 'Male voices';
+
+  @override
+  String get voiceFemale => 'Female voices';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2011,4 +2011,25 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get categoryInanimate => 'Inanimate';
+
+  @override
+  String get voiceSelection => 'AI Voice';
+
+  @override
+  String get voiceSelectionDescription =>
+      'Choose the voice Cortex speaks with in voice mode.';
+
+  @override
+  String get voiceDefaultOption => 'Default';
+
+  @override
+  String get voicePreview => 'Play sample';
+
+  @override
+  String get voicePreviewText =>
+      'Hello, I am Cortex. How can I help you today?';
+
+  @override
+  String get voicePreviewFailed =>
+      'Could not play the sample. Check your connection or balance.';
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -922,5 +922,11 @@
   "renameConversation": "Sohbeti Yeniden Adlandır",
   "conversationName": "Sohbet Adı",
   "deleteConversationConfirm": "Bu sohbeti silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.",
-  "archive": "Arşivle"
+  "archive": "Arşivle",
+  "voiceSelection": "Yapay Zeka Sesi",
+  "voiceSelectionDescription": "Cortex’in sesli sohbette kullanacağı sesi seçin.",
+  "voiceDefaultOption": "Varsayılan",
+  "voicePreview": "Örnek dinle",
+  "voicePreviewText": "Merhaba, ben Cortex. Bugün sana nasıl yardımcı olabilirim?",
+  "voicePreviewFailed": "Örnek çalınamadı. Bağlantını veya bakiyeni kontrol et."
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -928,5 +928,7 @@
   "voiceDefaultOption": "Varsayılan",
   "voicePreview": "Örnek dinle",
   "voicePreviewText": "Merhaba, ben Cortex. Bugün sana nasıl yardımcı olabilirim?",
-  "voicePreviewFailed": "Örnek çalınamadı. Bağlantını veya bakiyeni kontrol et."
+  "voicePreviewFailed": "Örnek çalınamadı. Bağlantını veya bakiyeni kontrol et.",
+  "voiceMale": "Erkek sesleri",
+  "voiceFemale": "Kadın sesleri"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'chat/services/context.dart';
 import 'chat/services/database.dart';
 import 'chat/services/offline.dart';
 import 'chat/services/read.dart';
+import 'chat/services/voice_catalog.dart';
 import 'chat/services/regenerate.dart';
 import 'chat/services/response.dart';
 import 'chat/services/scroll.dart';
@@ -410,6 +411,12 @@ List<SingleChildWidget> _buildCoreProviders(AppStatus initialStatus,
     ),
     ChangeNotifierProvider<InternetProvider>(
       create: (_) => InternetProvider(),
+    ),
+
+    // Published voice list plus this device's choice. Loaded eagerly so the
+    // settings row and voice mode agree from the first frame.
+    ChangeNotifierProvider<VoiceCatalogProvider>(
+      create: (_) => VoiceCatalogProvider()..load(),
     ),
 
     // User data & credits.

--- a/lib/settings/controller.dart
+++ b/lib/settings/controller.dart
@@ -18,6 +18,7 @@ import 'sections/header.dart';
 import 'sections/language.dart';
 import 'sections/settings.dart';
 import 'sections/theme.dart';
+import 'sections/voice.dart';
 import 'sections/personalization.dart';
 import 'sections/user.dart';
 import 'skeleton.dart';
@@ -144,6 +145,8 @@ class _SettingsScreenState extends State<SettingsScreen>
       const AppLanguageSection(),
       SizedBox(height: isTablet ? 24.0 : screenWidth * 0.04),
       const AppThemeSection(),
+      SizedBox(height: isTablet ? 24.0 : screenWidth * 0.04),
+      const VoiceSection(),
       SizedBox(height: isTablet ? 24.0 : screenWidth * 0.04),
       const PersonalizationSection(),
       SizedBox(height: isTablet ? 24.0 : screenWidth * 0.04),

--- a/lib/settings/sections/voice.dart
+++ b/lib/settings/sections/voice.dart
@@ -1,0 +1,292 @@
+// lib/settings/sections/voice.dart
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+
+import '../../app.dart';
+import '../../chat/services/tts_remote.dart';
+import '../../chat/services/voice_catalog.dart';
+import '../../l10n/app_localizations.dart';
+import '../../theme.dart';
+
+/// Lets the user choose which voice Cortex speaks with in voice mode.
+///
+/// The list is published in Firestore rather than built into the app, so this
+/// section hides itself entirely when no voices are configured — an empty
+/// picker is worse than no picker, and the server falls back to its default
+/// either way.
+class VoiceSection extends StatelessWidget {
+  const VoiceSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    context.watch<ThemeProvider>();
+    final catalog = context.watch<VoiceCatalogProvider>();
+    final localizations = AppLocalizations.of(context)!;
+
+    if (catalog.voices.isEmpty) return const SizedBox.shrink();
+
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    final selected = catalog.selectedVoice;
+    final currentName = selected?.name ?? localizations.voiceDefaultOption;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          localizations.voiceSelection,
+          style: TextStyle(
+            color: AppColors.primaryColor.inverted,
+            fontSize: screenWidth * 0.05,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        SizedBox(height: screenHeight * 0.01),
+        Text(
+          localizations.voiceSelectionDescription,
+          style: TextStyle(
+            color: AppColors.quinaryColor,
+            fontSize: screenWidth * 0.035,
+          ),
+        ),
+        SizedBox(height: screenHeight * 0.02),
+        Material(
+          color: AppColors.secondaryColor,
+          borderRadius: BorderRadius.circular(10.0),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: () {
+              HapticFeedback.lightImpact();
+              _showVoiceSelectionDialog(context);
+            },
+            borderRadius: BorderRadius.circular(10.0),
+            splashColor: AppColors.quaternaryColor.withValues(alpha: 0.3),
+            child: Container(
+              padding: EdgeInsets.symmetric(
+                vertical: screenHeight * 0.02,
+                horizontal: screenWidth * 0.04,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      currentName,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: AppColors.primaryColor.inverted,
+                        fontSize: screenWidth * 0.041,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  Icon(
+                    Icons.arrow_forward_ios,
+                    color: AppColors.primaryColor.inverted,
+                    size: screenWidth * 0.04,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _showVoiceSelectionDialog(BuildContext context) async {
+    final catalog = context.read<VoiceCatalogProvider>();
+    final localizations = AppLocalizations.of(context)!;
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => _VoiceSelectionDialog(
+        catalog: catalog,
+        localizations: localizations,
+      ),
+    );
+  }
+}
+
+class _VoiceSelectionDialog extends StatefulWidget {
+  const _VoiceSelectionDialog({
+    required this.catalog,
+    required this.localizations,
+  });
+
+  final VoiceCatalogProvider catalog;
+  final AppLocalizations localizations;
+
+  @override
+  State<_VoiceSelectionDialog> createState() => _VoiceSelectionDialogState();
+}
+
+class _VoiceSelectionDialogState extends State<_VoiceSelectionDialog> {
+  /// Which row is currently fetching or playing its sample. Only one at a time
+  /// — overlapping samples are unlistenable and each one costs credits.
+  String? _previewingId;
+
+  @override
+  void dispose() {
+    // Leaving the dialog mid-sample should stop it, not let it play on over
+    // whatever the user opened next.
+    RemoteTtsService.instance.stop();
+    super.dispose();
+  }
+
+  Future<void> _preview(String voiceId) async {
+    if (_previewingId != null) {
+      await RemoteTtsService.instance.stop();
+      if (_previewingId == voiceId) {
+        if (mounted) setState(() => _previewingId = null);
+        return;
+      }
+    }
+
+    setState(() => _previewingId = voiceId);
+
+    final audio = await RemoteTtsService.instance.synthesize(
+      widget.localizations.voicePreviewText,
+      voiceId: voiceId,
+    );
+
+    if (!mounted) return;
+    if (audio == null) {
+      setState(() => _previewingId = null);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(widget.localizations.voicePreviewFailed)),
+      );
+      return;
+    }
+
+    await RemoteTtsService.instance.play(audio);
+    if (mounted && _previewingId == voiceId) {
+      setState(() => _previewingId = null);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+    final voices = widget.catalog.voices;
+    final selectedId = widget.catalog.effectiveVoiceId;
+
+    return Dialog(
+      backgroundColor: AppColors.secondaryColor,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14.0)),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: screenHeight * 0.7),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(
+                screenWidth * 0.05,
+                screenHeight * 0.025,
+                screenWidth * 0.05,
+                screenHeight * 0.012,
+              ),
+              child: Text(
+                widget.localizations.voiceSelection,
+                style: TextStyle(
+                  color: AppColors.primaryColor.inverted,
+                  fontSize: screenWidth * 0.048,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            Flexible(
+              child: ListView.builder(
+                shrinkWrap: true,
+                padding: EdgeInsets.only(bottom: screenHeight * 0.012),
+                itemCount: voices.length,
+                itemBuilder: (context, index) {
+                  final voice = voices[index];
+                  final isSelected = voice.id == selectedId;
+                  final isPreviewing = _previewingId == voice.id;
+
+                  return InkWell(
+                    onTap: () async {
+                      HapticFeedback.selectionClick();
+                      await widget.catalog.select(voice.id);
+                      if (context.mounted) Navigator.of(context).pop();
+                    },
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: screenWidth * 0.05,
+                        vertical: screenHeight * 0.015,
+                      ),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  voice.name,
+                                  style: TextStyle(
+                                    color: AppColors.primaryColor.inverted,
+                                    fontSize: screenWidth * 0.042,
+                                    fontWeight: isSelected
+                                        ? FontWeight.w600
+                                        : FontWeight.w400,
+                                  ),
+                                ),
+                                if (voice.description != null) ...[
+                                  SizedBox(height: screenHeight * 0.004),
+                                  Text(
+                                    voice.description!,
+                                    style: TextStyle(
+                                      color: AppColors.quinaryColor,
+                                      fontSize: screenWidth * 0.033,
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                          IconButton(
+                            tooltip: widget.localizations.voicePreview,
+                            onPressed: () {
+                              HapticFeedback.lightImpact();
+                              _preview(voice.id);
+                            },
+                            icon: isPreviewing
+                                ? SizedBox(
+                                    width: screenWidth * 0.045,
+                                    height: screenWidth * 0.045,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: AppColors.primaryColor.inverted,
+                                    ),
+                                  )
+                                : Icon(
+                                    Icons.play_circle_outline,
+                                    color: AppColors.primaryColor.inverted,
+                                    size: screenWidth * 0.055,
+                                  ),
+                          ),
+                          if (isSelected)
+                            Icon(
+                              Icons.check,
+                              color: AppColors.primaryColor.inverted,
+                              size: screenWidth * 0.05,
+                            ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/settings/sections/voice.dart
+++ b/lib/settings/sections/voice.dart
@@ -111,6 +111,17 @@ class VoiceSection extends StatelessWidget {
   }
 }
 
+/// One row in the dialog: either a group heading or a voice.
+class _Entry {
+  const _Entry.header(this.header) : voice = null;
+  const _Entry.voice(this.voice) : header = null;
+
+  final String? header;
+  final CortexVoice? voice;
+
+  bool get isHeader => header != null;
+}
+
 class _VoiceSelectionDialog extends StatefulWidget {
   const _VoiceSelectionDialog({
     required this.catalog,
@@ -168,11 +179,35 @@ class _VoiceSelectionDialogState extends State<_VoiceSelectionDialog> {
     }
   }
 
+  /// Groups the catalog by gender, keeping the catalog's own order inside each
+  /// group. A group with nothing in it contributes no heading, so a catalog
+  /// that labels nothing still reads as a plain list.
+  List<_Entry> _entriesFor(List<CortexVoice> voices) {
+    final entries = <_Entry>[];
+    final groups = <VoiceGender, String?>{
+      VoiceGender.female: widget.localizations.voiceFemale,
+      VoiceGender.male: widget.localizations.voiceMale,
+      VoiceGender.unspecified: null,
+    };
+
+    for (final entry in groups.entries) {
+      final inGroup = voices.where((v) => v.gender == entry.key).toList();
+      if (inGroup.isEmpty) continue;
+      final heading = entry.value;
+      // Only label the ungrouped remainder when there is something to
+      // distinguish it from.
+      if (heading != null) entries.add(_Entry.header(heading));
+      entries.addAll(inGroup.map(_Entry.voice));
+    }
+    return entries;
+  }
+
   @override
   Widget build(BuildContext context) {
     final screenWidth = MediaQuery.of(context).size.width;
     final screenHeight = MediaQuery.of(context).size.height;
     final voices = widget.catalog.voices;
+    final entries = _entriesFor(voices);
     final selectedId = widget.catalog.effectiveVoiceId;
 
     return Dialog(
@@ -204,9 +239,31 @@ class _VoiceSelectionDialogState extends State<_VoiceSelectionDialog> {
               child: ListView.builder(
                 shrinkWrap: true,
                 padding: EdgeInsets.only(bottom: screenHeight * 0.012),
-                itemCount: voices.length,
+                itemCount: entries.length,
                 itemBuilder: (context, index) {
-                  final voice = voices[index];
+                  final entry = entries[index];
+
+                  if (entry.isHeader) {
+                    return Padding(
+                      padding: EdgeInsets.fromLTRB(
+                        screenWidth * 0.05,
+                        screenHeight * 0.016,
+                        screenWidth * 0.05,
+                        screenHeight * 0.006,
+                      ),
+                      child: Text(
+                        entry.header!,
+                        style: TextStyle(
+                          color: AppColors.quinaryColor,
+                          fontSize: screenWidth * 0.032,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0.6,
+                        ),
+                      ),
+                    );
+                  }
+
+                  final voice = entry.voice!;
                   final isSelected = voice.id == selectedId;
                   final isPreviewing = _previewingId == voice.id;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+814
+version: 8.1.1+815
 environment:
   sdk: '>=3.4.3 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+813
+version: 8.1.1+814
 environment:
   sdk: '>=3.4.3 <4.0.0'
 


### PR DESCRIPTION
Voice mode spoke with whatever the server nominated. This adds a picker in settings.

## The list lives in Firestore, not in the app

```
server/voice → {
  defaultVoiceId: "...",
  voices: [ { id, name, description? }, ... ]
}
```

Voices can then be added, reordered or replaced without shipping a release.

The section **hides itself when no voices are configured** — an empty picker is worse than none, and the server falls back to its default either way. So this ships inert and nothing regresses until the document is populated.

## Where the choice lives

SharedPreferences, not the account: it is a preference, it should survive being offline, and it does not need to follow the user between devices.

Stored as **null rather than as the current default**, deliberately — "no choice" then tracks the published default as it changes, instead of pinning whatever it happened to be on first launch. A selection that is no longer published is dropped on load rather than sent to the provider to be rejected.

## Preview

Each row can be auditioned before committing to it. This matters more than it sounds: voices trained on English vary a lot in Turkish, and the name tells you nothing.

Preview passes an explicit `voiceId` so it can play a voice the user has not selected yet. Voice mode passes none and picks up the stored choice from `RemoteTtsService.activeVoiceId`, so it does not reach for a provider on every sentence.

Only one sample plays at a time — overlapping samples are unlistenable and each one costs credits — and leaving the dialog stops playback.

## Strings

English and Turkish. The other 18 locales fall back to English until translated.

## Verification

`dart analyze lib/` is clean — zero errors, and the seven remaining infos are pre-existing deprecations in files this PR does not touch.

Not exercised on a device; the preview path depends on `synthesizeSpeech` being deployed and `ELEVENLABS_API_KEY` being set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)