### PR TITLE
feat(credits): follow the daily credit engine on the client

### DIFF
--- a/lib/chat/messages/options/change.dart
+++ b/lib/chat/messages/options/change.dart
@@ -54,10 +54,17 @@ Future<void> showModelSelectionDialog({
     return m.attachmentPaths.any((path) => _isImageFile(path));
   });
 
+  final creditsManager = context.read<CreditsManager>();
+
+  // The daily credit engine hands model choice to paid tiers with credit left.
+  // Below that the gateway answers with Dynamic Chat whatever is picked here,
+  // so a dialog would only offer a choice that gets overridden on send.
+  if (!creditsManager.canChooseModel) return;
+
   // Premium access. Billing v2 has no premium lane — anything the user can
   // afford is allowed — so this asks the balance, not a separate currency.
-  final hasPremiumAccess = session.isUserSubscribed ||
-      context.read<CreditsManager>().canUsePremiumModel;
+  final hasPremiumAccess =
+      session.isUserSubscribed || creditsManager.canUsePremiumModel;
   final Set<String> downloadedModelIds =
       (await UserModels.loadDownloadedModelPaths()).keys.toSet();
 

--- a/lib/chat/messages/options/panel.dart
+++ b/lib/chat/messages/options/panel.dart
@@ -114,10 +114,16 @@ class OptionsPanelViewModel {
     final isDynamicContext = session.isDynamicChat;
     final isOfflineModel = modelSeriesData?.isServerSide == false;
 
+    final creditsManager = context.read<CreditsManager>();
+
     // Billing v2 has no premium lane, so this is a balance question. The
     // getter keeps the old predit check for unmigrated accounts.
-    final hasPreditsForPremium = session.isUserSubscribed ||
-        context.read<CreditsManager>().canUsePremiumModel;
+    final hasPreditsForPremium =
+        session.isUserSubscribed || creditsManager.canUsePremiumModel;
+
+    // Under the daily engine, model choice is a paid feature that also closes
+    // when a paid balance runs out.
+    final canChooseModel = creditsManager.canChooseModel;
 
     final isCurrentModelPremium = currentModel.isPremium;
 
@@ -147,6 +153,7 @@ class OptionsPanelViewModel {
       }
 
       if (option == MessageOption.changeModel) {
+        if (!isOfflineModel && !canChooseModel) return false;
         if (!isOfflineModel && totalCredits <= 0) return false;
         if (!isDynamicContext) {
           if (modelSeriesData != null) {

--- a/lib/chat/screen/widgets/bottom/input/service.dart
+++ b/lib/chat/screen/widgets/bottom/input/service.dart
@@ -340,15 +340,26 @@ class InputService {
     // lazy migration has not touched yet.
     final creditsManager = context.read<CreditsManager>();
 
-    if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
-      if (!creditsManager.canUsePremiumModel) {
-        return false;
-      }
+    // Past the debt floor nothing is sendable until the allowance renews, and
+    // that holds for every lane rather than the one the user happens to be in.
+    if (!creditsManager.canSendAnything) {
+      return false;
     }
 
-    if (isDynamicChatMode) {
-      if (!creditsManager.canSendDynamicChat) {
-        return false;
+    // The lane-specific currencies below exist only outside the daily engine.
+    // Under it a model the user may not choose is rewritten to Dynamic Chat
+    // rather than refused, so it is not a reason to disable sending.
+    if (!creditsManager.creditsV3Notifier.value) {
+      if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
+        if (!creditsManager.canUsePremiumModel) {
+          return false;
+        }
+      }
+
+      if (isDynamicChatMode) {
+        if (!creditsManager.canSendDynamicChat) {
+          return false;
+        }
       }
     }
 
@@ -417,15 +428,26 @@ class InputService {
     // lazy migration has not touched yet.
     final creditsManager = context.read<CreditsManager>();
 
-    if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
-      if (!creditsManager.canUsePremiumModel) {
-        return false;
-      }
+    // Past the debt floor nothing is sendable until the allowance renews, and
+    // that holds for every lane rather than the one the user happens to be in.
+    if (!creditsManager.canSendAnything) {
+      return false;
     }
 
-    if (isDynamicChatMode) {
-      if (!creditsManager.canSendDynamicChat) {
-        return false;
+    // The lane-specific currencies below exist only outside the daily engine.
+    // Under it a model the user may not choose is rewritten to Dynamic Chat
+    // rather than refused, so it is not a reason to disable sending.
+    if (!creditsManager.creditsV3Notifier.value) {
+      if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
+        if (!creditsManager.canUsePremiumModel) {
+          return false;
+        }
+      }
+
+      if (isDynamicChatMode) {
+        if (!creditsManager.canSendDynamicChat) {
+          return false;
+        }
       }
     }
 

--- a/lib/chat/services/send.dart
+++ b/lib/chat/services/send.dart
@@ -12,6 +12,7 @@ import 'package:cortex/chat/providers/conversation.dart';
 import 'package:cortex/chat/providers/input.dart';
 import 'package:cortex/chat/providers/session.dart';
 import 'package:cortex/chat/services/api.dart';
+import 'package:cortex/server/credits.dart';
 import 'package:cortex/chat/services/background.dart';
 import 'package:cortex/chat/services/context.dart';
 import 'package:cortex/chat/services/moderator.dart';
@@ -355,9 +356,11 @@ class SendService {
 
       final localState = context.read<ModelLocalStateProvider>();
       final langCode = Localizations.localeOf(context).languageCode;
+      // Read before the await below; the context must not be touched across it.
+      final creditsManager = context.read<CreditsManager>();
       final hasInternet = await InternetConnection().hasInternetAccess;
 
-      final originalUiModelId = overrideModelId ??
+      var originalUiModelId = overrideModelId ??
           (sessionProvider.isDynamicChat
               ? 'cortex/auto'
               : sessionProvider.modelId) ??
@@ -369,6 +372,19 @@ class SendService {
         apiModelIdForSend = 'cortex/auto';
       } else {
         apiModelIdForSend = sessionProvider.modelId;
+      }
+
+      // Under the daily credit engine, model choice belongs to paid tiers with
+      // credit left; everyone else is answered by Dynamic Chat. The gateway
+      // applies this regardless, so applying it here too keeps the message
+      // labelled with the model that actually answered it.
+      //
+      // The session's preferred model is left alone on purpose — when the
+      // allowance renews tomorrow the user gets it back without having to pick
+      // it again.
+      if (!creditsManager.canChooseModel) {
+        apiModelIdForSend = 'cortex/auto';
+        originalUiModelId = 'cortex/auto';
       }
 
       final intentResolvedModelId = _resolveAttachmentIntentModelId(

--- a/lib/server/credits.dart
+++ b/lib/server/credits.dart
@@ -5,6 +5,25 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
+/// The access bands of the daily credit engine, mirroring `ACCESS` in
+/// functions/src/credits.js. The strings are the server's, not ours, so a
+/// mismatch is a compile-time typo rather than a silent wrong gate.
+abstract final class CreditAccess {
+  static const String full = 'full';
+  static const String lowOnly = 'low_only';
+  static const String blocked = 'blocked';
+}
+
+/// Daily allowance per tier, mirroring `DAILY_GRANTS` in
+/// functions/src/credits.js. Needed here only to locate the debt floor, which
+/// is one grant below zero.
+const Map<String, int> _dailyGrants = {
+  'free': 100,
+  'plus': 500,
+  'pro': 1000,
+  'ultra': 10000,
+};
+
 /// Central, singleton-style service that keeps the **current user’s**
 /// credit balance in memory for UI display purposes and provides a real-time
 /// stream of the total credit value.
@@ -30,6 +49,23 @@ class CreditsManager {
   /// and every gate has to ask which one it is looking at.
   final ValueNotifier<bool> billingV2Notifier = ValueNotifier<bool>(false);
 
+  /// Whether the daily credit engine is the one billing this account. Set by
+  /// the server the first time it renews the allowance, so it turns on for a
+  /// user at the same moment the gateway starts charging them that way.
+  final ValueNotifier<bool> creditsV3Notifier = ValueNotifier<bool>(false);
+
+  /// What the balance permits, mirroring `accessFor` in
+  /// functions/src/credits.js:
+  ///
+  ///   full      everything the tier allows
+  ///   low_only  Dynamic Chat, cheapest mode, no model choice
+  ///   blocked   nothing until the allowance renews
+  ///
+  /// The server decides this again on every request; the client tracks it only
+  /// so the UI can stop offering what would be refused.
+  final ValueNotifier<String> accessNotifier =
+      ValueNotifier<String>(CreditAccess.full);
+
   /// What the user can actually spend: the allowance bucket plus owned
   /// credits. This is the number the server gates on, so the client gates on
   /// the same one instead of guessing from a display total.
@@ -40,11 +76,37 @@ class CreditsManager {
   /// a failure the user cannot act on.
   static const int minTextBalance = 50;
 
+  /// Whether the user may pick a specific model, as opposed to being answered
+  /// by Dynamic Chat.
+  ///
+  /// Two separate things close this door and the server treats them the same
+  /// way: model choice is a paid feature, and it is also the first thing to go
+  /// when a paid balance runs out. Deliberately *not* OR'd with the
+  /// subscription flag — a subscriber in the debt band has lost the privilege
+  /// just as a free user never had it, and offering a picker whose choice the
+  /// gateway would silently override is worse than not offering one.
+  ///
+  /// Outside the daily engine this stays true and the old premium filters keep
+  /// deciding what the picker shows.
+  bool get canChooseModel {
+    if (!creditsV3Notifier.value) return true;
+    return accessNotifier.value == CreditAccess.full && _tierIsPaid;
+  }
+
+  /// Whether anything at all can be sent. Only the floor closes this.
+  bool get canSendAnything {
+    if (!creditsV3Notifier.value) return true;
+    return accessNotifier.value != CreditAccess.blocked;
+  }
+
+  bool _tierIsPaid = false;
+
   /// Under billing v2 there is no premium lane — every model bills its real
   /// cost, so anything the user can afford is allowed and this is the only
   /// question worth asking. Before migration it falls back to the predit
   /// balance the old engine maintained.
   bool get canUsePremiumModel {
+    if (creditsV3Notifier.value) return canChooseModel;
     if (billingV2Notifier.value) {
       return (spendableNotifier.value ?? 0) >= minTextBalance;
     }
@@ -52,8 +114,11 @@ class CreditsManager {
   }
 
   /// Dynamic Chat had its own currency (dredits) under the old engine. v2
-  /// retires it: a dynamic turn is billed like any other text turn.
+  /// retires it: a dynamic turn is billed like any other text turn. The daily
+  /// engine goes further — Dynamic Chat is what the user is *left* with in the
+  /// debt band, so it stays open until the floor.
   bool get canSendDynamicChat {
+    if (creditsV3Notifier.value) return canSendAnything;
     if (billingV2Notifier.value) {
       return (spendableNotifier.value ?? 0) >= minTextBalance;
     }
@@ -85,6 +150,56 @@ class CreditsManager {
     return fallback;
   }
 
+  /// Mirrors `resolveTier` in functions/src/credits.js. Levels 4-6 are lifetime
+  /// grants and carry no expiry; 1-3 lapse back to free.
+  String _resolveTier(Map<String, dynamic> data) {
+    final level = _readInt(data['hasCortexSubscription'], 0);
+    if (level == 0) return 'free';
+
+    final lifetime = level >= 4 && level <= 6;
+    if (!lifetime) {
+      final raw = data['subscriptionExpiresAt'];
+      final expiry = raw is Timestamp ? raw.toDate() : null;
+      if (expiry == null || !expiry.isAfter(DateTime.now())) return 'free';
+    }
+
+    switch (level) {
+      case 1:
+      case 4:
+        return 'plus';
+      case 2:
+      case 5:
+        return 'pro';
+      case 3:
+      case 6:
+        return 'ultra';
+      default:
+        return 'free';
+    }
+  }
+
+  /// Mirrors `accessFor` in functions/src/credits.js. The floor is measured on
+  /// the allowance alone, so a purchased wallet widens the top band without
+  /// letting the user go further into debt.
+  String _accessFor(int allowance, int purchased, int grant) {
+    final spendable = allowance + (purchased < 0 ? 0 : purchased);
+    if (spendable > 0) return CreditAccess.full;
+    if (allowance > -grant) return CreditAccess.lowOnly;
+    return CreditAccess.blocked;
+  }
+
+  /// Puts the engine flags back to a neutral state.
+  ///
+  /// Neutral means *open*, not blocked: the server is the real gate, and
+  /// failing closed here would lock a user out of their own app over a
+  /// transient Firestore error.
+  void _resetEngineFlags() {
+    billingV2Notifier.value = false;
+    creditsV3Notifier.value = false;
+    accessNotifier.value = CreditAccess.full;
+    _tierIsPaid = false;
+  }
+
   bool _isStaleListener(int generation, String uid) {
     final currentUid = FirebaseAuth.instance.currentUser?.uid;
     return generation != _listenerGeneration ||
@@ -106,7 +221,7 @@ class CreditsManager {
       preditsNotifier.value = 0;
       dreditsNotifier.value = 0;
       spendableNotifier.value = 0;
-      billingV2Notifier.value = false;
+      _resetEngineFlags();
       return;
     }
 
@@ -133,10 +248,34 @@ class CreditsManager {
       if (snapshot.exists) {
         final data = snapshot.data() ?? {};
         final billingV2 = data['billingV2'] == true;
+        final creditsV3 = data['creditsV3'] == true;
         final main = _readInt(data['credits'], 0);
         billingV2Notifier.value = billingV2;
+        creditsV3Notifier.value = creditsV3;
 
-        if (billingV2) {
+        if (creditsV3) {
+          // One balance: the daily allowance plus whatever was purchased.
+          // `credits` is the wallet and never renews, which is why the two are
+          // kept apart on the server and only added up for display here.
+          final allowance = _readFloor(data['dailyCredits'], 0);
+          final spendable = allowance + main;
+          final tier = _resolveTier(data);
+          final grant = _dailyGrants[tier] ?? _dailyGrants['free']!;
+
+          _tierIsPaid = tier != 'free';
+          accessNotifier.value = _accessFor(allowance, main, grant);
+
+          totalCreditsNotifier.value = spendable;
+          spendableNotifier.value = spendable;
+          // The legacy notifiers still drive a few overlays. Feeding them the
+          // one balance keeps those readouts honest rather than showing a
+          // currency that no longer moves.
+          preditsNotifier.value = spendable;
+          dreditsNotifier.value = spendable;
+
+          debugPrint(
+              "Balances updated (v3): Spendable=$spendable (allowance=$allowance, owned=$main), tier=$tier, access=${accessNotifier.value}");
+        } else if (billingV2) {
           // One currency. Spendable is the allowance bucket plus owned
           // credits — exactly what authorizeRequest checks server-side.
           // predits/dredits still arrive as legacy mirrors for older clients;
@@ -171,6 +310,7 @@ class CreditsManager {
         preditsNotifier.value = 0;
         dreditsNotifier.value = 0;
         spendableNotifier.value = 0;
+        _resetEngineFlags();
       }
     }, onError: (error) {
       if (_isStaleListener(generation, uid)) {
@@ -184,6 +324,7 @@ class CreditsManager {
       preditsNotifier.value = 0;
       dreditsNotifier.value = 0;
       spendableNotifier.value = 0;
+      _resetEngineFlags();
     });
   }
 
@@ -197,6 +338,6 @@ class CreditsManager {
     preditsNotifier.value = null;
     dreditsNotifier.value = null;
     spendableNotifier.value = null;
-    billingV2Notifier.value = false;
+    _resetEngineFlags();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+815
+version: 8.1.1+816
 environment:
   sdk: '>=3.4.3 <4.0.0'
 


### PR DESCRIPTION
Server side: VertexCorporation/Fulcrum#12.

The gateway now bills one balance, renewed daily per tier, and narrows what is available as it falls. This makes the app agree with it instead of offering choices the server would override.

## What changes

`CreditsManager` reads the allowance and the access band alongside the purchased wallet, mirroring `accessFor` and `resolveTier` from `functions/src/credits.js` so the two cannot drift into disagreeing about who is allowed what.

Model choice disappears in two cases the server treats identically: a free tier that never had it, and a paid one that has spent its allowance. The picker and the change-model option are **hidden rather than shown-and-ignored**, and the send path labels the message `cortex/auto` so the bubble names the model that actually answered.

The session's preferred model is deliberately left alone — when the allowance renews tomorrow the user gets it back without picking it again.

Past the debt floor nothing sends at all. Above it, Dynamic Chat stays open: that band is the point where a user is out of credit but not out of the product.

## Failure is open, not closed

A missing document or a Firestore error resets the engine flags to their neutral state, which is permissive. The server is the real gate, and locking someone out of their own app over a dropped connection would be the worse mistake.

## Inert until the server says otherwise

`creditsV3` is written by the gateway on first renewal. Every new gate is a no-op while it is absent, so this ships ahead of the switch safely.

⚠️ Once the switch is on, **free users lose the model picker entirely** — that is what the spec asks for, but it is the most visible change in this pair and worth a deliberate decision rather than a surprise.

`versionCode` → 816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)