### PR TITLE
feat(tts): read messages aloud in the voice the user picked

### DIFF
--- a/lib/chat/messages/options/change.dart
+++ b/lib/chat/messages/options/change.dart
@@ -54,10 +54,17 @@ Future<void> showModelSelectionDialog({
     return m.attachmentPaths.any((path) => _isImageFile(path));
   });
 
+  final creditsManager = context.read<CreditsManager>();
+
+  // The daily credit engine hands model choice to paid tiers with credit left.
+  // Below that the gateway answers with Dynamic Chat whatever is picked here,
+  // so a dialog would only offer a choice that gets overridden on send.
+  if (!creditsManager.canChooseModel) return;
+
   // Premium access. Billing v2 has no premium lane — anything the user can
   // afford is allowed — so this asks the balance, not a separate currency.
-  final hasPremiumAccess = session.isUserSubscribed ||
-      context.read<CreditsManager>().canUsePremiumModel;
+  final hasPremiumAccess =
+      session.isUserSubscribed || creditsManager.canUsePremiumModel;
   final Set<String> downloadedModelIds =
       (await UserModels.loadDownloadedModelPaths()).keys.toSet();
 

--- a/lib/chat/messages/options/panel.dart
+++ b/lib/chat/messages/options/panel.dart
@@ -114,10 +114,16 @@ class OptionsPanelViewModel {
     final isDynamicContext = session.isDynamicChat;
     final isOfflineModel = modelSeriesData?.isServerSide == false;
 
+    final creditsManager = context.read<CreditsManager>();
+
     // Billing v2 has no premium lane, so this is a balance question. The
     // getter keeps the old predit check for unmigrated accounts.
-    final hasPreditsForPremium = session.isUserSubscribed ||
-        context.read<CreditsManager>().canUsePremiumModel;
+    final hasPreditsForPremium =
+        session.isUserSubscribed || creditsManager.canUsePremiumModel;
+
+    // Under the daily engine, model choice is a paid feature that also closes
+    // when a paid balance runs out.
+    final canChooseModel = creditsManager.canChooseModel;
 
     final isCurrentModelPremium = currentModel.isPremium;
 
@@ -147,6 +153,7 @@ class OptionsPanelViewModel {
       }
 
       if (option == MessageOption.changeModel) {
+        if (!isOfflineModel && !canChooseModel) return false;
         if (!isOfflineModel && totalCredits <= 0) return false;
         if (!isDynamicContext) {
           if (modelSeriesData != null) {

--- a/lib/chat/screen/widgets/bottom/input/service.dart
+++ b/lib/chat/screen/widgets/bottom/input/service.dart
@@ -340,15 +340,26 @@ class InputService {
     // lazy migration has not touched yet.
     final creditsManager = context.read<CreditsManager>();
 
-    if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
-      if (!creditsManager.canUsePremiumModel) {
-        return false;
-      }
+    // Past the debt floor nothing is sendable until the allowance renews, and
+    // that holds for every lane rather than the one the user happens to be in.
+    if (!creditsManager.canSendAnything) {
+      return false;
     }
 
-    if (isDynamicChatMode) {
-      if (!creditsManager.canSendDynamicChat) {
-        return false;
+    // The lane-specific currencies below exist only outside the daily engine.
+    // Under it a model the user may not choose is rewritten to Dynamic Chat
+    // rather than refused, so it is not a reason to disable sending.
+    if (!creditsManager.creditsV3Notifier.value) {
+      if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
+        if (!creditsManager.canUsePremiumModel) {
+          return false;
+        }
+      }
+
+      if (isDynamicChatMode) {
+        if (!creditsManager.canSendDynamicChat) {
+          return false;
+        }
       }
     }
 
@@ -417,15 +428,26 @@ class InputService {
     // lazy migration has not touched yet.
     final creditsManager = context.read<CreditsManager>();
 
-    if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
-      if (!creditsManager.canUsePremiumModel) {
-        return false;
-      }
+    // Past the debt floor nothing is sendable until the allowance renews, and
+    // that holds for every lane rather than the one the user happens to be in.
+    if (!creditsManager.canSendAnything) {
+      return false;
     }
 
-    if (isDynamicChatMode) {
-      if (!creditsManager.canSendDynamicChat) {
-        return false;
+    // The lane-specific currencies below exist only outside the daily engine.
+    // Under it a model the user may not choose is rewritten to Dynamic Chat
+    // rather than refused, so it is not a reason to disable sending.
+    if (!creditsManager.creditsV3Notifier.value) {
+      if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
+        if (!creditsManager.canUsePremiumModel) {
+          return false;
+        }
+      }
+
+      if (isDynamicChatMode) {
+        if (!creditsManager.canSendDynamicChat) {
+          return false;
+        }
       }
     }
 

--- a/lib/chat/services/send.dart
+++ b/lib/chat/services/send.dart
@@ -12,6 +12,7 @@ import 'package:cortex/chat/providers/conversation.dart';
 import 'package:cortex/chat/providers/input.dart';
 import 'package:cortex/chat/providers/session.dart';
 import 'package:cortex/chat/services/api.dart';
+import 'package:cortex/server/credits.dart';
 import 'package:cortex/chat/services/background.dart';
 import 'package:cortex/chat/services/context.dart';
 import 'package:cortex/chat/services/moderator.dart';
@@ -355,9 +356,11 @@ class SendService {
 
       final localState = context.read<ModelLocalStateProvider>();
       final langCode = Localizations.localeOf(context).languageCode;
+      // Read before the await below; the context must not be touched across it.
+      final creditsManager = context.read<CreditsManager>();
       final hasInternet = await InternetConnection().hasInternetAccess;
 
-      final originalUiModelId = overrideModelId ??
+      var originalUiModelId = overrideModelId ??
           (sessionProvider.isDynamicChat
               ? 'cortex/auto'
               : sessionProvider.modelId) ??
@@ -369,6 +372,19 @@ class SendService {
         apiModelIdForSend = 'cortex/auto';
       } else {
         apiModelIdForSend = sessionProvider.modelId;
+      }
+
+      // Under the daily credit engine, model choice belongs to paid tiers with
+      // credit left; everyone else is answered by Dynamic Chat. The gateway
+      // applies this regardless, so applying it here too keeps the message
+      // labelled with the model that actually answered it.
+      //
+      // The session's preferred model is left alone on purpose — when the
+      // allowance renews tomorrow the user gets it back without having to pick
+      // it again.
+      if (!creditsManager.canChooseModel) {
+        apiModelIdForSend = 'cortex/auto';
+        originalUiModelId = 'cortex/auto';
       }
 
       final intentResolvedModelId = _resolveAttachmentIntentModelId(

--- a/lib/chat/services/speech.dart
+++ b/lib/chat/services/speech.dart
@@ -38,20 +38,46 @@ class SpeechService with ChangeNotifier {
 
   bool get isDeviceSupported => _isDeviceSupported;
 
+  /// Initialises the on-device recogniser with both of its callbacks.
+  ///
+  /// `speech_to_text` keeps the handlers from the first successful
+  /// `initialize` and ignores the ones passed to later calls. The availability
+  /// check runs at startup and wins that race, so registering `onStatus` only
+  /// at listen time meant it was never registered at all: `_isListening`
+  /// stayed false for the whole device-recogniser session, which killed the
+  /// waveform (it is gated on that flag) and made voice mode drop straight
+  /// back to idle the moment it looked at the flag.
+  ///
+  /// Both callbacks therefore live here, and every caller goes through this.
+  Future<bool> _initializeDevice() async {
+    return _speech.initialize(
+      onStatus: (status) {
+        // Deepgram drives its own state; the device engine is not running.
+        if (_usingRemote) return;
+        _isListening = status == 'listening';
+        if (!_isListening) _soundLevel = 0.0;
+        notifyListeners();
+      },
+      onError: (e) {
+        if (_usingRemote) return;
+        _isListening = false;
+        _soundLevel = 0.0;
+        // Only the OS lacking an engine is permanent. Network hiccups and
+        // silence timeouts must not hide the feature.
+        if (e.errorMsg.contains('recognition service') ||
+            e.errorMsg.contains('SpeechRecognizer')) {
+          _isDeviceSupported = false;
+        }
+        debugPrint("Speech error: ${e.errorMsg}");
+        notifyListeners();
+      },
+    );
+  }
+
   /// Lightweight availability check.
   Future<void> checkAvailability() async {
     try {
-      bool available = await _speech.initialize(
-        onError: (e) {
-          // Only permanently disable buttons if the OS lacks the engine
-          if (e.errorMsg.contains('recognition service') ||
-              e.errorMsg.contains('SpeechRecognizer')) {
-            _isDeviceSupported = false;
-            notifyListeners();
-          }
-          debugPrint("Speech Availability Error: ${e.errorMsg}");
-        },
-      );
+      final available = await _initializeDevice();
       if (available) {
         _isAvailable = true;
         _isDeviceSupported = true;
@@ -69,51 +95,18 @@ class SpeechService with ChangeNotifier {
     required String locale,
     required Function(String text) onResult,
   }) async {
-    if (!_isDeviceSupported) return;
-
-    // Ensure initialized if not already
-    if (!_isAvailable) {
-      bool initSuccess = false;
-      try {
-        initSuccess = await _speech.initialize(
-          onStatus: (status) {
-            _isListening = status == 'listening';
-            if (!_isListening) {
-              _soundLevel = 0.0;
-            }
-            notifyListeners();
-          },
-          onError: (errorNotification) {
-            _isListening = false;
-            _soundLevel = 0.0;
-            // Note: We DO NOT set _isDeviceSupported=false here.
-            // Temporary errors (network, silence) should not hide the feature.
-            notifyListeners();
-          },
-        );
-      } on PlatformException catch (e) {
-        debugPrint("Speech recognition not available (PlatformException): $e");
-        _isDeviceSupported = false;
-        notifyListeners();
-        return;
-      } catch (e) {
-        debugPrint("Speech initialization failed in startListening: $e");
-        _isDeviceSupported = false;
-        notifyListeners();
-        return;
-      }
-
-      if (!initSuccess) {
-        // Initialization failed, but maybe temporary.
-        return;
-      }
-      _isAvailable = true;
-    }
-
     _localeId = locale;
 
-    // Try Deepgram first. It returns false without starting anything when it
-    // cannot run, so falling through costs nothing.
+    // Deepgram first, and before the on-device engine is touched at all.
+    //
+    // It needs nothing from the OS recogniser, so a phone that lacks one —
+    // old hardware, no Google apps, the service disabled — should still be
+    // able to dictate. The previous order asked the OS for permission to
+    // proceed and gave up on exactly the devices the remote path exists to
+    // serve.
+    //
+    // `start` returns false without having started anything when it cannot
+    // run, so falling through to the fallback costs nothing.
     _finalizedText = "";
     final startedRemote = await _remote.start(
       onResult: (result) {
@@ -137,6 +130,32 @@ class SpeechService with ChangeNotifier {
       _remote.soundLevel.addListener(_onRemoteLevel);
       notifyListeners();
       return;
+    }
+
+    // ── Fallback: the on-device recogniser ──
+    if (!_isDeviceSupported) return;
+
+    if (!_isAvailable) {
+      bool initSuccess = false;
+      try {
+        initSuccess = await _initializeDevice();
+      } on PlatformException catch (e) {
+        debugPrint("Speech recognition not available (PlatformException): $e");
+        _isDeviceSupported = false;
+        notifyListeners();
+        return;
+      } catch (e) {
+        debugPrint("Speech initialization failed in startListening: $e");
+        _isDeviceSupported = false;
+        notifyListeners();
+        return;
+      }
+
+      if (!initSuccess) {
+        // Initialization failed, but maybe temporary.
+        return;
+      }
+      _isAvailable = true;
     }
 
     await _speech.listen(

--- a/lib/chat/services/stt_remote.dart
+++ b/lib/chat/services/stt_remote.dart
@@ -73,6 +73,13 @@ class RemoteSttService {
   Completer<void>? _firstChunk;
   bool _closing = false;
 
+  // Enough of the session to tell the difference between a microphone that
+  // never produced anything, audio that Deepgram never answered, and a
+  // transcript that arrived. A session the user simply ends leaves no other
+  // trace, so "it did nothing" and "it worked" looked identical from here.
+  int _chunksSent = 0;
+  int _transcriptsSeen = 0;
+
   bool get isActive => _socket != null;
 
   /// Latest microphone loudness, 0..1, derived from the PCM the recorder hands
@@ -237,7 +244,10 @@ class RemoteSttService {
       (dynamic message) {
         if (message is! String) return;
         final result = _parseTranscript(message);
-        if (result != null) onResult(result);
+        if (result != null) {
+          _transcriptsSeen++;
+          onResult(result);
+        }
       },
       onError: (Object e) {
         _fail("SOCKET_ERROR", e);
@@ -307,6 +317,7 @@ class RemoteSttService {
       _micSubscription = stream.listen(
         (chunk) {
           if (!(_firstChunk?.isCompleted ?? true)) _firstChunk!.complete();
+          _chunksSent++;
           soundLevel.value = _levelOf(chunk);
 
           final socket = _socket;
@@ -362,6 +373,19 @@ class RemoteSttService {
   /// Closes the microphone and the socket, asking Deepgram to flush whatever
   /// it is still holding so the last words are not lost.
   Future<void> stop() async {
+    // A session that captured audio and got nothing back is the case with no
+    // other symptom: the socket behaved, the waveform moved, and the text
+    // field stayed empty. Record it before the counters are cleared.
+    if (_chunksSent > 0 && _transcriptsSeen == 0 && _socket != null) {
+      _fail("NO_TRANSCRIPT", "chunks=$_chunksSent");
+      // Sent now rather than waiting to ride along with the next token
+      // request: a user who gets nothing back tends not to try again, and
+      // that is exactly the session worth hearing about.
+      unawaited(_report());
+    }
+    _chunksSent = 0;
+    _transcriptsSeen = 0;
+
     _closing = true;
     soundLevel.value = 0.0;
     _pending.clear();

--- a/lib/chat/services/stt_remote.dart
+++ b/lib/chat/services/stt_remote.dart
@@ -56,9 +56,21 @@ class RemoteSttService {
     receiveTimeout: const Duration(seconds: 15),
   ));
 
+  /// How long to wait for the first buffer before deciding a microphone is
+  /// not going to produce one. Android normally delivers within a couple of
+  /// hundred milliseconds, and nothing waits on the full window when it does.
+  static const Duration _audioProbe = Duration(milliseconds: 1500);
+
+  /// Speech captured while the socket is still being opened, so the opening
+  /// words are not lost. Bounded: a socket that never arrives must not grow
+  /// this without limit. 200 buffers of 16 kHz mono is a few seconds.
+  static const int _maxPendingChunks = 200;
+
   AudioRecorder? _recorder;
   WebSocket? _socket;
   StreamSubscription<Uint8List>? _micSubscription;
+  final List<Uint8List> _pending = [];
+  Completer<void>? _firstChunk;
   bool _closing = false;
 
   bool get isActive => _socket != null;
@@ -82,6 +94,38 @@ class RemoteSttService {
   void _fail(String code, [Object? detail]) {
     _lastFailure = detail == null ? code : "$code: $detail";
     debugPrint("[RemoteStt] $_lastFailure");
+  }
+
+  /// Sends the last failure on its own, buying nothing.
+  ///
+  /// Used when the session ends before a token is needed. The server
+  /// recognises `reportOnly` and logs without charging, so diagnosing a broken
+  /// microphone never costs the user credits.
+  Future<void> _report() async {
+    final failure = _lastFailure;
+    if (failure == null) return;
+    _lastFailure = null;
+
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) return;
+      final idToken = await user.getIdToken();
+      if (idToken == null) return;
+
+      await _dio.post<Map<String, dynamic>>(
+        _tokenEndpoint,
+        data: <String, dynamic>{'lastFailure': failure, 'reportOnly': true},
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $idToken',
+            'Content-Type': 'application/json; charset=UTF-8',
+          },
+          validateStatus: (_) => true,
+        ),
+      );
+    } catch (e) {
+      debugPrint("[RemoteStt] Could not report failure: $e");
+    }
   }
 
   /// Asks the server for a short-lived Deepgram token. Returns null when
@@ -126,12 +170,21 @@ class RemoteSttService {
   ///
   /// Returns false if the remote path could not be established, in which case
   /// nothing has been started and the caller should use the on-device engine.
+  ///
+  /// The microphone is opened and proven to be producing audio *before* a
+  /// token is asked for. That ordering matters twice over. A grant costs the
+  /// user credits, and a device whose microphone yields nothing was being
+  /// charged for a session that could never transcribe a word. It also fixes
+  /// the diagnosis: Deepgram closes an idle socket with a generic timeout, so
+  /// a silent microphone used to surface as a network-looking error several
+  /// steps away from the actual fault.
   Future<bool> start({
     required void Function(SttResult result) onResult,
     void Function()? onClosed,
   }) async {
     if (_socket != null) return true;
     _closing = false;
+    _pending.clear();
 
     final recorder = AudioRecorder();
     try {
@@ -146,13 +199,29 @@ class RemoteSttService {
       return false;
     }
 
-    final token = await _fetchToken();
-    if (token == null) {
-      _fail("NO_TOKEN");
-      await recorder.dispose();
+    _recorder = recorder;
+
+    // ── 1. A microphone that is actually recording ──
+    if (!await _openMicrophone(recorder, onClosed: onClosed)) {
+      // Nothing further will be requested, so this failure would never reach
+      // the server on its own — and a microphone that never yields audio is
+      // exactly the failure worth seeing. Reported explicitly, without buying
+      // anything.
+      unawaited(_report());
+      await stop();
       return false;
     }
 
+    // ── 2. Now that there is audio to send, buy a token ──
+    final token = await _fetchToken();
+    if (token == null) {
+      _fail("NO_TOKEN");
+      await stop();
+      return false;
+    }
+
+    // ── 3. The socket. Speech captured while it opens is buffered, so the
+    //       first word survives the round trip. ──
     try {
       _socket = await WebSocket.connect(
         _listenUrl,
@@ -160,12 +229,9 @@ class RemoteSttService {
       ).timeout(const Duration(seconds: 10));
     } catch (e) {
       _fail("CONNECT_FAILED", e);
-      await recorder.dispose();
-      _socket = null;
+      await stop();
       return false;
     }
-
-    _recorder = recorder;
 
     _socket!.listen(
       (dynamic message) {
@@ -193,64 +259,104 @@ class RemoteSttService {
       cancelOnError: true,
     );
 
-    final stream = await _openMicrophone(recorder);
-    if (stream == null) {
-      await stop();
-      return false;
-    }
-
-    _micSubscription = stream.listen(
-      (chunk) {
-        soundLevel.value = _levelOf(chunk);
-        final socket = _socket;
-        if (socket != null && socket.readyState == WebSocket.open) {
-          socket.add(chunk);
-        }
-      },
-      onError: (Object e) {
-        _fail("MIC_ERROR", e);
-        unawaited(stop());
-        onClosed?.call();
-      },
-      cancelOnError: true,
-    );
-
     return true;
   }
 
-  /// Opens the microphone, dropping the audio effects if they are what the
-  /// device objects to.
+  /// Starts recording and waits for the device to prove it by handing over a
+  /// buffer.
   ///
-  /// `echoCancel` and `noiseSuppress` map onto Android's AcousticEchoCanceler
-  /// and NoiseSuppressor, which are hardware features a lot of older phones
-  /// simply do not have. Asking for them there can fail the whole recording
-  /// rather than being ignored, so the second attempt gives them up: worse
-  /// audio for Deepgram to work with beats no audio at all.
-  Future<Stream<Uint8List>?> _openMicrophone(AudioRecorder recorder) async {
-    const base = RecordConfig(
+  /// `echoCancel` and `noiseSuppress` make record_android ask for the
+  /// VOICE_COMMUNICATION audio source instead of the plain microphone. On some
+  /// hardware that source starts without complaint and then stays silent
+  /// forever — `startStream` succeeds, `isRecording` reports true, and not one
+  /// buffer ever arrives. Waiting for real audio is the only way to catch it,
+  /// since nothing throws.
+  ///
+  /// The second attempt gives up the effects. Worse audio for Deepgram to work
+  /// with beats no audio at all.
+  Future<bool> _openMicrophone(
+    AudioRecorder recorder, {
+    void Function()? onClosed,
+  }) async {
+    const withEffects = RecordConfig(
       encoder: AudioEncoder.pcm16bits,
       sampleRate: _sampleRate,
       numChannels: 1,
       echoCancel: true,
       noiseSuppress: true,
     );
+    const plain = RecordConfig(
+      encoder: AudioEncoder.pcm16bits,
+      sampleRate: _sampleRate,
+      numChannels: 1,
+    );
 
-    try {
-      return await recorder.startStream(base);
-    } catch (e) {
-      _fail("MIC_START_FAILED", e);
+    for (final attempt in const [
+      (config: withEffects, label: "with_effects"),
+      (config: plain, label: "plain"),
+    ]) {
+      final Stream<Uint8List> stream;
+      try {
+        stream = await recorder.startStream(attempt.config);
+      } catch (e) {
+        _fail("MIC_START_FAILED_${attempt.label}", e);
+        continue;
+      }
+
+      _firstChunk = Completer<void>();
+      _micSubscription = stream.listen(
+        (chunk) {
+          if (!(_firstChunk?.isCompleted ?? true)) _firstChunk!.complete();
+          soundLevel.value = _levelOf(chunk);
+
+          final socket = _socket;
+          if (socket != null && socket.readyState == WebSocket.open) {
+            if (_pending.isNotEmpty) {
+              for (final held in _pending) {
+                socket.add(held);
+              }
+              _pending.clear();
+            }
+            socket.add(chunk);
+          } else if (_pending.length < _maxPendingChunks) {
+            _pending.add(chunk);
+          }
+        },
+        onError: (Object e) {
+          _fail("MIC_ERROR", e);
+          unawaited(stop());
+          onClosed?.call();
+        },
+        cancelOnError: true,
+      );
+
+      var gotAudio = true;
+      try {
+        await _firstChunk!.future.timeout(_audioProbe);
+      } on TimeoutException {
+        gotAudio = false;
+      }
+
+      if (gotAudio) return true;
+
+      var recording = false;
+      try {
+        recording = await recorder.isRecording();
+      } catch (_) {}
+      _fail(
+        "NO_AUDIO_${attempt.label}",
+        "isRecording=$recording after ${_audioProbe.inMilliseconds}ms",
+      );
+
+      await _micSubscription?.cancel();
+      _micSubscription = null;
+      _pending.clear();
+      try {
+        await recorder.stop();
+      } catch (_) {}
     }
 
-    try {
-      return await recorder.startStream(const RecordConfig(
-        encoder: AudioEncoder.pcm16bits,
-        sampleRate: _sampleRate,
-        numChannels: 1,
-      ));
-    } catch (e) {
-      _fail("MIC_START_FAILED_PLAIN", e);
-      return null;
-    }
+    return false;
   }
 
   /// Closes the microphone and the socket, asking Deepgram to flush whatever
@@ -258,6 +364,8 @@ class RemoteSttService {
   Future<void> stop() async {
     _closing = true;
     soundLevel.value = 0.0;
+    _pending.clear();
+    _firstChunk = null;
 
     await _micSubscription?.cancel();
     _micSubscription = null;

--- a/lib/chat/services/stt_remote.dart
+++ b/lib/chat/services/stt_remote.dart
@@ -20,6 +20,8 @@ import 'dart:math' as math;
 import 'package:dio/dio.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:record/record.dart';
 
 /// One transcript update. Deepgram sends a running best guess and then a
@@ -98,6 +100,40 @@ class RemoteSttService {
   /// and nothing extra on the happy path.
   String? _lastFailure;
 
+  /// Build number and hardware, attached to every report.
+  ///
+  /// Two testers on two builds produced logs that could not be told apart,
+  /// and the microphone question is a hardware question — which phone, which
+  /// Android — so guessing at it from the server was hopeless. Gathered once
+  /// and cached; failures are rare and this must never be the reason one goes
+  /// unreported.
+  Map<String, dynamic>? _context;
+
+  Future<Map<String, dynamic>> _deviceContext() async {
+    final cached = _context;
+    if (cached != null) return cached;
+
+    final gathered = <String, dynamic>{};
+    try {
+      gathered["build"] = (await PackageInfo.fromPlatform()).buildNumber;
+    } catch (_) {}
+    try {
+      final plugin = DeviceInfoPlugin();
+      if (Platform.isAndroid) {
+        final a = await plugin.androidInfo;
+        gathered["device"] = "${a.manufacturer} ${a.model}";
+        gathered["os"] = "Android ${a.version.release} (SDK ${a.version.sdkInt})";
+      } else if (Platform.isIOS) {
+        final i = await plugin.iosInfo;
+        gathered["device"] = i.utsname.machine;
+        gathered["os"] = "iOS ${i.systemVersion}";
+      }
+    } catch (_) {}
+
+    _context = gathered;
+    return gathered;
+  }
+
   void _fail(String code, [Object? detail]) {
     _lastFailure = detail == null ? code : "$code: $detail";
     debugPrint("[RemoteStt] $_lastFailure");
@@ -121,7 +157,11 @@ class RemoteSttService {
 
       await _dio.post<Map<String, dynamic>>(
         _tokenEndpoint,
-        data: <String, dynamic>{'lastFailure': failure, 'reportOnly': true},
+        data: <String, dynamic>{
+          'lastFailure': failure,
+          'reportOnly': true,
+          ...await _deviceContext(),
+        },
         options: Options(
           headers: {
             'Authorization': 'Bearer $idToken',
@@ -150,7 +190,10 @@ class RemoteSttService {
       final response = await _dio.post<Map<String, dynamic>>(
         _tokenEndpoint,
         data: <String, dynamic>{
-          if (previousFailure != null) 'lastFailure': previousFailure,
+          if (previousFailure != null) ...{
+            'lastFailure': previousFailure,
+            ...await _deviceContext(),
+          },
         },
         options: Options(
           headers: {
@@ -196,12 +239,18 @@ class RemoteSttService {
     final recorder = AudioRecorder();
     try {
       if (!await recorder.hasPermission()) {
+        // Reported like any other failure. This one returns before a token is
+        // ever needed, so without saying so explicitly a device that simply
+        // never got microphone permission is invisible from the server —
+        // indistinguishable from a tester who did not try.
         _fail("PERMISSION_DENIED");
+        unawaited(_report());
         await recorder.dispose();
         return false;
       }
     } catch (e) {
       _fail("PERMISSION_CHECK_FAILED", e);
+      unawaited(_report());
       await recorder.dispose();
       return false;
     }

--- a/lib/chat/services/stt_remote.dart
+++ b/lib/chat/services/stt_remote.dart
@@ -68,6 +68,22 @@ class RemoteSttService {
   /// measured, otherwise the waveform in the UI would sit still.
   final ValueNotifier<double> soundLevel = ValueNotifier<double>(0.0);
 
+  /// Why the last attempt fell back, carried to the server on the next token
+  /// request.
+  ///
+  /// Everything in this file degrades to false rather than throwing, which is
+  /// right for the user and useless for diagnosis: a failure is indistinguishable
+  /// from the feature not existing, and the only trace is a `debugPrint` on a
+  /// device we do not have. Piggy-backing the reason onto a call the client
+  /// already makes puts it in the function logs instead, with no new endpoint
+  /// and nothing extra on the happy path.
+  String? _lastFailure;
+
+  void _fail(String code, [Object? detail]) {
+    _lastFailure = detail == null ? code : "$code: $detail";
+    debugPrint("[RemoteStt] $_lastFailure");
+  }
+
   /// Asks the server for a short-lived Deepgram token. Returns null when
   /// dictation is unavailable — no session, no balance, provider down.
   Future<String?> _fetchToken() async {
@@ -77,9 +93,14 @@ class RemoteSttService {
       final idToken = await user.getIdToken();
       if (idToken == null) return null;
 
+      final previousFailure = _lastFailure;
+      _lastFailure = null;
+
       final response = await _dio.post<Map<String, dynamic>>(
         _tokenEndpoint,
-        data: const <String, dynamic>{},
+        data: <String, dynamic>{
+          if (previousFailure != null) 'lastFailure': previousFailure,
+        },
         options: Options(
           headers: {
             'Authorization': 'Bearer $idToken',
@@ -115,18 +136,19 @@ class RemoteSttService {
     final recorder = AudioRecorder();
     try {
       if (!await recorder.hasPermission()) {
-        debugPrint("[RemoteStt] Microphone permission denied.");
+        _fail("PERMISSION_DENIED");
         await recorder.dispose();
         return false;
       }
     } catch (e) {
-      debugPrint("[RemoteStt] Permission check failed: $e");
+      _fail("PERMISSION_CHECK_FAILED", e);
       await recorder.dispose();
       return false;
     }
 
     final token = await _fetchToken();
     if (token == null) {
+      _fail("NO_TOKEN");
       await recorder.dispose();
       return false;
     }
@@ -137,7 +159,7 @@ class RemoteSttService {
         headers: {'Authorization': 'Bearer $token'},
       ).timeout(const Duration(seconds: 10));
     } catch (e) {
-      debugPrint("[RemoteStt] Connect failed: $e");
+      _fail("CONNECT_FAILED", e);
       await recorder.dispose();
       _socket = null;
       return false;
@@ -152,50 +174,83 @@ class RemoteSttService {
         if (result != null) onResult(result);
       },
       onError: (Object e) {
-        debugPrint("[RemoteStt] Socket error: $e");
+        _fail("SOCKET_ERROR", e);
         unawaited(stop());
         onClosed?.call();
       },
       onDone: () {
-        if (!_closing) onClosed?.call();
+        // A close we did not ask for carries Deepgram's reason for it.
+        if (!_closing) {
+          final socket = _socket;
+          _fail(
+            "SOCKET_CLOSED",
+            "code=${socket?.closeCode} reason=${socket?.closeReason}",
+          );
+          onClosed?.call();
+        }
         unawaited(stop());
       },
       cancelOnError: true,
     );
 
-    try {
-      final stream = await recorder.startStream(
-        const RecordConfig(
-          encoder: AudioEncoder.pcm16bits,
-          sampleRate: _sampleRate,
-          numChannels: 1,
-          echoCancel: true,
-          noiseSuppress: true,
-        ),
-      );
-
-      _micSubscription = stream.listen(
-        (chunk) {
-          soundLevel.value = _levelOf(chunk);
-          final socket = _socket;
-          if (socket != null && socket.readyState == WebSocket.open) {
-            socket.add(chunk);
-          }
-        },
-        onError: (Object e) {
-          debugPrint("[RemoteStt] Microphone error: $e");
-          unawaited(stop());
-          onClosed?.call();
-        },
-        cancelOnError: true,
-      );
-    } catch (e) {
-      debugPrint("[RemoteStt] Could not start microphone: $e");
+    final stream = await _openMicrophone(recorder);
+    if (stream == null) {
       await stop();
       return false;
     }
 
+    _micSubscription = stream.listen(
+      (chunk) {
+        soundLevel.value = _levelOf(chunk);
+        final socket = _socket;
+        if (socket != null && socket.readyState == WebSocket.open) {
+          socket.add(chunk);
+        }
+      },
+      onError: (Object e) {
+        _fail("MIC_ERROR", e);
+        unawaited(stop());
+        onClosed?.call();
+      },
+      cancelOnError: true,
+    );
+
     return true;
+  }
+
+  /// Opens the microphone, dropping the audio effects if they are what the
+  /// device objects to.
+  ///
+  /// `echoCancel` and `noiseSuppress` map onto Android's AcousticEchoCanceler
+  /// and NoiseSuppressor, which are hardware features a lot of older phones
+  /// simply do not have. Asking for them there can fail the whole recording
+  /// rather than being ignored, so the second attempt gives them up: worse
+  /// audio for Deepgram to work with beats no audio at all.
+  Future<Stream<Uint8List>?> _openMicrophone(AudioRecorder recorder) async {
+    const base = RecordConfig(
+      encoder: AudioEncoder.pcm16bits,
+      sampleRate: _sampleRate,
+      numChannels: 1,
+      echoCancel: true,
+      noiseSuppress: true,
+    );
+
+    try {
+      return await recorder.startStream(base);
+    } catch (e) {
+      _fail("MIC_START_FAILED", e);
+    }
+
+    try {
+      return await recorder.startStream(const RecordConfig(
+        encoder: AudioEncoder.pcm16bits,
+        sampleRate: _sampleRate,
+        numChannels: 1,
+      ));
+    } catch (e) {
+      _fail("MIC_START_FAILED_PLAIN", e);
+      return null;
+    }
   }
 
   /// Closes the microphone and the socket, asking Deepgram to flush whatever
@@ -237,7 +292,21 @@ class RemoteSttService {
     try {
       final decoded = jsonDecode(raw);
       if (decoded is! Map<String, dynamic>) return null;
-      if (decoded['type'] != 'Results') return null;
+
+      // Deepgram reports a rejected request as a message on the open socket
+      // rather than by refusing the upgrade — a bad model or an unsupported
+      // language arrives here, not at connect time. Dropping everything that
+      // is not a transcript would turn that into silence with no explanation.
+      final type = decoded['type'];
+      if (type == 'Error' || decoded['err_code'] != null) {
+        _fail(
+          "DEEPGRAM_ERROR",
+          decoded['err_msg'] ?? decoded['description'] ?? raw,
+        );
+        return null;
+      }
+
+      if (type != 'Results') return null;
 
       final alternatives =
           decoded['channel']?['alternatives'] as List<dynamic>?;

--- a/lib/chat/services/tts.dart
+++ b/lib/chat/services/tts.dart
@@ -3,10 +3,18 @@
 // Text-to-Speech service for reading messages aloud.
 
 import 'dart:async';
+import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 
+import 'tts_remote.dart';
+
 enum TtsState { idle, playing, paused }
+
+/// Which engine is speaking. The device recogniser and the remote voice have
+/// different notions of position and completion, so every transport control
+/// has to know which one it is talking to.
+enum _TtsEngine { device, remote }
 
 class TtsService with ChangeNotifier {
   static final TtsService _instance = TtsService._internal();
@@ -14,6 +22,36 @@ class TtsService with ChangeNotifier {
   TtsService._internal();
 
   final FlutterTts _flutterTts = FlutterTts();
+
+  // ── Remote voice ─────────────────────────────────────────────────────────
+  //
+  // Reading a message aloud used to be the one place the app still spoke in
+  // the device's robot voice, which reads as a bug once the user has picked a
+  // voice in settings. It now uses the same voice as voice mode, and keeps the
+  // device engine for when that is not possible — offline, out of credit, or
+  // synthesis simply failing.
+  //
+  // Playback is driven here rather than through RemoteTtsService.play, which
+  // returns only when the audio has finished. The player UI needs pause,
+  // resume and seek, so it needs the player itself.
+
+  /// The server takes 800 characters per request, so a message is spoken in
+  /// pieces. Sentence boundaries are preferred; the limit is what decides.
+  static const int _remoteChunkLimit = 700;
+
+  AudioPlayer? _remotePlayer;
+  StreamSubscription<void>? _remoteComplete;
+  StreamSubscription<Duration>? _remotePosition;
+  StreamSubscription<Duration>? _remoteDurationSub;
+  Duration? _remoteDurationCache;
+
+  _TtsEngine _engine = _TtsEngine.device;
+
+  /// The message split for the remote voice, with the character offset each
+  /// piece starts at, so progress can be reported against the whole text
+  /// rather than the piece being spoken.
+  List<String> _chunks = const [];
+  List<int> _chunkStarts = const [];
 
   TtsState _state = TtsState.idle;
   Timer? _ttsTimer;
@@ -202,12 +240,179 @@ class TtsService with ChangeNotifier {
     _currentText = textChunk; // This is the chunk currently being spoken
     _state = TtsState.playing;
     notifyListeners();
+
+    // The picked voice first. It falls back rather than failing, so a device
+    // that cannot reach it still reads the message aloud.
+    if (await _speakRemote(textChunk)) return;
+
+    _engine = _TtsEngine.device;
     await _flutterTts.speak(textChunk);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // REMOTE VOICE
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /// Splits text into pieces the server will accept, breaking at sentence
+  /// ends where it can and mid-text only when a single sentence is too long
+  /// to send.
+  List<String> _splitForRemote(String text) {
+    final pieces = <String>[];
+    final sentences = text.split(RegExp(r'(?<=[.!?…])\s+'));
+
+    var current = "";
+    void flush() {
+      final trimmed = current.trim();
+      if (trimmed.isNotEmpty) pieces.add(trimmed);
+      current = "";
+    }
+
+    for (final sentence in sentences) {
+      if (sentence.length > _remoteChunkLimit) {
+        flush();
+        for (var i = 0; i < sentence.length; i += _remoteChunkLimit) {
+          final end = (i + _remoteChunkLimit).clamp(0, sentence.length);
+          pieces.add(sentence.substring(i, end).trim());
+        }
+        continue;
+      }
+      if (current.length + sentence.length + 1 > _remoteChunkLimit) flush();
+      current = current.isEmpty ? sentence : "$current $sentence";
+    }
+    flush();
+
+    return pieces.where((p) => p.isNotEmpty).toList(growable: false);
+  }
+
+  /// Starts the remote voice. Returns false when it could not speak at all,
+  /// leaving nothing playing so the caller can use the device engine.
+  Future<bool> _speakRemote(String text) async {
+    await _stopRemote();
+
+    final pieces = _splitForRemote(text);
+    if (pieces.isEmpty) return false;
+
+    // Offsets are measured against the text actually spoken, so the progress
+    // bar tracks the whole message rather than restarting at each piece.
+    final starts = <int>[];
+    var offset = 0;
+    for (final piece in pieces) {
+      starts.add(offset);
+      offset += piece.length + 1;
+    }
+
+    _chunks = pieces;
+    _chunkStarts = starts;
+    _engine = _TtsEngine.remote;
+
+    if (await _playChunk(0)) return true;
+
+    // Nothing was produced; leave no trace for the device engine to trip over.
+    _engine = _TtsEngine.device;
+    _chunks = const [];
+    _chunkStarts = const [];
+    return false;
+  }
+
+  Future<bool> _playChunk(int index) async {
+    if (index < 0 || index >= _chunks.length) return false;
+
+    final bytes = await RemoteTtsService.instance.synthesize(_chunks[index]);
+    if (bytes == null) return false;
+
+    try {
+      final player = _remotePlayer ??= AudioPlayer();
+      await player.stop();
+
+      await _remoteComplete?.cancel();
+      await _remotePosition?.cancel();
+      await _remoteDurationSub?.cancel();
+
+      // Duration arrives after playback starts, so progress within a piece is
+      // reported only once it is known. Until then the bar sits at the piece's
+      // starting offset rather than jumping around.
+      _remoteDurationCache = null;
+      _remoteDurationSub = player.onDurationChanged.listen((d) {
+        _remoteDurationCache = d;
+      });
+
+      _remotePosition = player.onPositionChanged.listen((position) {
+        _reportRemoteProgress(index, position);
+      });
+
+      _remoteComplete = player.onPlayerComplete.listen((_) {
+        unawaited(_advanceRemote(index));
+      });
+
+      await player.play(BytesSource(bytes));
+      _state = TtsState.playing;
+      notifyListeners();
+      return true;
+    } catch (e) {
+      debugPrint("[TtsService] Remote playback failed: $e");
+      return false;
+    }
+  }
+
+  void _reportRemoteProgress(int index, Duration position) {
+    if (_engine != _TtsEngine.remote || _originalText.isEmpty) return;
+    if (index >= _chunkStarts.length) return;
+
+    final total = _remoteDurationCache;
+    final chunkLength = _chunks[index].length;
+
+    var within = 0.0;
+    if (total != null && total.inMilliseconds > 0) {
+      within = position.inMilliseconds / total.inMilliseconds;
+      if (within > 1.0) within = 1.0;
+    }
+
+    final spoken = _chunkStarts[index] + (chunkLength * within);
+    _progress = (spoken / _originalText.length).clamp(0.0, 1.0);
+    notifyListeners();
+  }
+
+  /// Moves to the next piece, or settles as finished.
+  Future<void> _advanceRemote(int finished) async {
+    if (_engine != _TtsEngine.remote) return;
+    if (_isInterrupted) return;
+
+    final next = finished + 1;
+    if (next < _chunks.length && await _playChunk(next)) return;
+
+    _state = TtsState.idle;
+    _progress = 1.0;
+    notifyListeners();
+
+    _ttsTimer = Timer(const Duration(milliseconds: 2000), () {
+      if (_state == TtsState.idle) {
+        _progress = 0.0;
+        _currentText = '';
+        notifyListeners();
+      }
+    });
+  }
+
+  Future<void> _stopRemote() async {
+    await _remoteComplete?.cancel();
+    await _remotePosition?.cancel();
+    await _remoteDurationSub?.cancel();
+    _remoteComplete = null;
+    _remotePosition = null;
+    _remoteDurationSub = null;
+    _remoteDurationCache = null;
+    try {
+      await _remotePlayer?.stop();
+    } catch (_) {}
   }
 
   Future<void> stop() async {
     _isInterrupted = false; // Allow completion handler to clean up
     _ttsTimer?.cancel();
+    await _stopRemote();
+    _engine = _TtsEngine.device;
+    _chunks = const [];
+    _chunkStarts = const [];
     await _flutterTts.stop();
     // Handler will be called, but we can double check:
     _state = TtsState.idle;
@@ -219,18 +424,41 @@ class TtsService with ChangeNotifier {
   }
 
   Future<void> pause() async {
-    if (_state == TtsState.playing) {
-      _isInterrupted = true; // Don't treat this as "finished"
-      await _flutterTts
-          .stop(); // Using stop to ensure we can restart from offset precisely
-      _state = TtsState.paused;
-      _isInterrupted = false;
-      notifyListeners();
+    if (_state != TtsState.playing) return;
+
+    _isInterrupted = true; // Don't treat this as "finished"
+    if (_engine == _TtsEngine.remote) {
+      // Real audio, so it can be suspended where it stands rather than
+      // restarted from a character offset.
+      try {
+        await _remotePlayer?.pause();
+      } catch (e) {
+        debugPrint("[TtsService] Remote pause failed: $e");
+      }
+    } else {
+      // Using stop so playback can restart from the offset precisely.
+      await _flutterTts.stop();
     }
+    _state = TtsState.paused;
+    _isInterrupted = false;
+    notifyListeners();
   }
 
   Future<void> resume() async {
-    if (_state == TtsState.paused && _originalText.isNotEmpty) {
+    if (_state != TtsState.paused) return;
+
+    if (_engine == _TtsEngine.remote) {
+      try {
+        await _remotePlayer?.resume();
+        _state = TtsState.playing;
+        notifyListeners();
+        return;
+      } catch (e) {
+        debugPrint("[TtsService] Remote resume failed: $e");
+      }
+    }
+
+    if (_originalText.isNotEmpty) {
       // Calculate text remaining based on last progress
       // Progress = (offset + current_chunk_pos) / total
       // We can approximate the resumption point based on _progress
@@ -247,6 +475,25 @@ class TtsService with ChangeNotifier {
     if (_originalText.isEmpty) return;
 
     _isInterrupted = true;
+
+    if (_engine == _TtsEngine.remote && _chunks.isNotEmpty) {
+      // Seeking lands on the piece containing that point and starts it from
+      // the beginning. Sub-piece accuracy would mean mapping characters onto
+      // milliseconds, which the audio gives no way to do honestly.
+      final target = (newProgress * _originalText.length).toInt();
+      var piece = 0;
+      for (var i = 0; i < _chunkStarts.length; i++) {
+        if (_chunkStarts[i] <= target) piece = i;
+      }
+      _isInterrupted = false;
+      _progress = newProgress;
+      notifyListeners();
+      if (await _playChunk(piece)) return;
+      // Falling through means the remote voice gave out mid-message; the
+      // device engine picks up from the requested point.
+      _engine = _TtsEngine.device;
+    }
+
     await _flutterTts.stop();
     _isInterrupted = false;
 
@@ -317,6 +564,9 @@ class TtsService with ChangeNotifier {
   @override
   void dispose() {
     _flutterTts.stop();
+    unawaited(_stopRemote());
+    _remotePlayer?.dispose();
+    _remotePlayer = null;
     super.dispose();
   }
 }

--- a/lib/server/credits.dart
+++ b/lib/server/credits.dart
@@ -5,6 +5,25 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
+/// The access bands of the daily credit engine, mirroring `ACCESS` in
+/// functions/src/credits.js. The strings are the server's, not ours, so a
+/// mismatch is a compile-time typo rather than a silent wrong gate.
+abstract final class CreditAccess {
+  static const String full = 'full';
+  static const String lowOnly = 'low_only';
+  static const String blocked = 'blocked';
+}
+
+/// Daily allowance per tier, mirroring `DAILY_GRANTS` in
+/// functions/src/credits.js. Needed here only to locate the debt floor, which
+/// is one grant below zero.
+const Map<String, int> _dailyGrants = {
+  'free': 100,
+  'plus': 500,
+  'pro': 1000,
+  'ultra': 10000,
+};
+
 /// Central, singleton-style service that keeps the **current user’s**
 /// credit balance in memory for UI display purposes and provides a real-time
 /// stream of the total credit value.
@@ -30,6 +49,23 @@ class CreditsManager {
   /// and every gate has to ask which one it is looking at.
   final ValueNotifier<bool> billingV2Notifier = ValueNotifier<bool>(false);
 
+  /// Whether the daily credit engine is the one billing this account. Set by
+  /// the server the first time it renews the allowance, so it turns on for a
+  /// user at the same moment the gateway starts charging them that way.
+  final ValueNotifier<bool> creditsV3Notifier = ValueNotifier<bool>(false);
+
+  /// What the balance permits, mirroring `accessFor` in
+  /// functions/src/credits.js:
+  ///
+  ///   full      everything the tier allows
+  ///   low_only  Dynamic Chat, cheapest mode, no model choice
+  ///   blocked   nothing until the allowance renews
+  ///
+  /// The server decides this again on every request; the client tracks it only
+  /// so the UI can stop offering what would be refused.
+  final ValueNotifier<String> accessNotifier =
+      ValueNotifier<String>(CreditAccess.full);
+
   /// What the user can actually spend: the allowance bucket plus owned
   /// credits. This is the number the server gates on, so the client gates on
   /// the same one instead of guessing from a display total.
@@ -40,11 +76,37 @@ class CreditsManager {
   /// a failure the user cannot act on.
   static const int minTextBalance = 50;
 
+  /// Whether the user may pick a specific model, as opposed to being answered
+  /// by Dynamic Chat.
+  ///
+  /// Two separate things close this door and the server treats them the same
+  /// way: model choice is a paid feature, and it is also the first thing to go
+  /// when a paid balance runs out. Deliberately *not* OR'd with the
+  /// subscription flag — a subscriber in the debt band has lost the privilege
+  /// just as a free user never had it, and offering a picker whose choice the
+  /// gateway would silently override is worse than not offering one.
+  ///
+  /// Outside the daily engine this stays true and the old premium filters keep
+  /// deciding what the picker shows.
+  bool get canChooseModel {
+    if (!creditsV3Notifier.value) return true;
+    return accessNotifier.value == CreditAccess.full && _tierIsPaid;
+  }
+
+  /// Whether anything at all can be sent. Only the floor closes this.
+  bool get canSendAnything {
+    if (!creditsV3Notifier.value) return true;
+    return accessNotifier.value != CreditAccess.blocked;
+  }
+
+  bool _tierIsPaid = false;
+
   /// Under billing v2 there is no premium lane — every model bills its real
   /// cost, so anything the user can afford is allowed and this is the only
   /// question worth asking. Before migration it falls back to the predit
   /// balance the old engine maintained.
   bool get canUsePremiumModel {
+    if (creditsV3Notifier.value) return canChooseModel;
     if (billingV2Notifier.value) {
       return (spendableNotifier.value ?? 0) >= minTextBalance;
     }
@@ -52,8 +114,11 @@ class CreditsManager {
   }
 
   /// Dynamic Chat had its own currency (dredits) under the old engine. v2
-  /// retires it: a dynamic turn is billed like any other text turn.
+  /// retires it: a dynamic turn is billed like any other text turn. The daily
+  /// engine goes further — Dynamic Chat is what the user is *left* with in the
+  /// debt band, so it stays open until the floor.
   bool get canSendDynamicChat {
+    if (creditsV3Notifier.value) return canSendAnything;
     if (billingV2Notifier.value) {
       return (spendableNotifier.value ?? 0) >= minTextBalance;
     }
@@ -85,6 +150,56 @@ class CreditsManager {
     return fallback;
   }
 
+  /// Mirrors `resolveTier` in functions/src/credits.js. Levels 4-6 are lifetime
+  /// grants and carry no expiry; 1-3 lapse back to free.
+  String _resolveTier(Map<String, dynamic> data) {
+    final level = _readInt(data['hasCortexSubscription'], 0);
+    if (level == 0) return 'free';
+
+    final lifetime = level >= 4 && level <= 6;
+    if (!lifetime) {
+      final raw = data['subscriptionExpiresAt'];
+      final expiry = raw is Timestamp ? raw.toDate() : null;
+      if (expiry == null || !expiry.isAfter(DateTime.now())) return 'free';
+    }
+
+    switch (level) {
+      case 1:
+      case 4:
+        return 'plus';
+      case 2:
+      case 5:
+        return 'pro';
+      case 3:
+      case 6:
+        return 'ultra';
+      default:
+        return 'free';
+    }
+  }
+
+  /// Mirrors `accessFor` in functions/src/credits.js. The floor is measured on
+  /// the allowance alone, so a purchased wallet widens the top band without
+  /// letting the user go further into debt.
+  String _accessFor(int allowance, int purchased, int grant) {
+    final spendable = allowance + (purchased < 0 ? 0 : purchased);
+    if (spendable > 0) return CreditAccess.full;
+    if (allowance > -grant) return CreditAccess.lowOnly;
+    return CreditAccess.blocked;
+  }
+
+  /// Puts the engine flags back to a neutral state.
+  ///
+  /// Neutral means *open*, not blocked: the server is the real gate, and
+  /// failing closed here would lock a user out of their own app over a
+  /// transient Firestore error.
+  void _resetEngineFlags() {
+    billingV2Notifier.value = false;
+    creditsV3Notifier.value = false;
+    accessNotifier.value = CreditAccess.full;
+    _tierIsPaid = false;
+  }
+
   bool _isStaleListener(int generation, String uid) {
     final currentUid = FirebaseAuth.instance.currentUser?.uid;
     return generation != _listenerGeneration ||
@@ -106,7 +221,7 @@ class CreditsManager {
       preditsNotifier.value = 0;
       dreditsNotifier.value = 0;
       spendableNotifier.value = 0;
-      billingV2Notifier.value = false;
+      _resetEngineFlags();
       return;
     }
 
@@ -133,10 +248,34 @@ class CreditsManager {
       if (snapshot.exists) {
         final data = snapshot.data() ?? {};
         final billingV2 = data['billingV2'] == true;
+        final creditsV3 = data['creditsV3'] == true;
         final main = _readInt(data['credits'], 0);
         billingV2Notifier.value = billingV2;
+        creditsV3Notifier.value = creditsV3;
 
-        if (billingV2) {
+        if (creditsV3) {
+          // One balance: the daily allowance plus whatever was purchased.
+          // `credits` is the wallet and never renews, which is why the two are
+          // kept apart on the server and only added up for display here.
+          final allowance = _readFloor(data['dailyCredits'], 0);
+          final spendable = allowance + main;
+          final tier = _resolveTier(data);
+          final grant = _dailyGrants[tier] ?? _dailyGrants['free']!;
+
+          _tierIsPaid = tier != 'free';
+          accessNotifier.value = _accessFor(allowance, main, grant);
+
+          totalCreditsNotifier.value = spendable;
+          spendableNotifier.value = spendable;
+          // The legacy notifiers still drive a few overlays. Feeding them the
+          // one balance keeps those readouts honest rather than showing a
+          // currency that no longer moves.
+          preditsNotifier.value = spendable;
+          dreditsNotifier.value = spendable;
+
+          debugPrint(
+              "Balances updated (v3): Spendable=$spendable (allowance=$allowance, owned=$main), tier=$tier, access=${accessNotifier.value}");
+        } else if (billingV2) {
           // One currency. Spendable is the allowance bucket plus owned
           // credits — exactly what authorizeRequest checks server-side.
           // predits/dredits still arrive as legacy mirrors for older clients;
@@ -171,6 +310,7 @@ class CreditsManager {
         preditsNotifier.value = 0;
         dreditsNotifier.value = 0;
         spendableNotifier.value = 0;
+        _resetEngineFlags();
       }
     }, onError: (error) {
       if (_isStaleListener(generation, uid)) {
@@ -184,6 +324,7 @@ class CreditsManager {
       preditsNotifier.value = 0;
       dreditsNotifier.value = 0;
       spendableNotifier.value = 0;
+      _resetEngineFlags();
     });
   }
 
@@ -197,6 +338,6 @@ class CreditsManager {
     preditsNotifier.value = null;
     dreditsNotifier.value = null;
     spendableNotifier.value = null;
-    billingV2Notifier.value = false;
+    _resetEngineFlags();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+815
+version: 8.1.1+817
 environment:
   sdk: '>=3.4.3 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+818
+version: 8.1.1+819
 environment:
   sdk: '>=3.4.3 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,8 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+819
+version: 8.1.1+820
+
 environment:
   sdk: '>=3.4.3 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+815
+version: 8.1.1+816
 environment:
   sdk: '>=3.4.3 <4.0.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Core of Artificial Intelligence"
 
 publish_to: 'none'
 
-version: 8.1.1+817
+version: 8.1.1+818
 environment:
   sdk: '>=3.4.3 <4.0.0'
 


### PR DESCRIPTION
Supersedes #8 and #9 — both are merged into this branch.

Reading a message aloud was the last place the app still spoke in the device's robot voice. Once a voice has been chosen in settings that reads as a bug, not a limitation: the user picked a voice and the app ignored it everywhere except voice mode.

It now speaks through the same voice, keeping the device engine for when that is not possible — offline, out of credit, or synthesis failing. Nothing is left playing when the remote attempt gives out, so the fallback starts cleanly.

## Why playback is driven in TtsService

`RemoteTtsService.play` returns only when the audio has finished. That is fine for voice mode and useless for a player with pause, resume and a scrubber, so this owns the `AudioPlayer` instead.

The transport controls keep working, and work better: position now comes from real audio rather than being estimated from character offsets the way `flutter_tts`'s progress handler forced.

The server takes 800 characters per request, so a message is spoken in pieces split at sentence ends where possible. Progress is reported against the whole message rather than the piece being spoken, so the bar does not restart every few seconds.

Seeking lands on the piece containing that point and starts it from the beginning. Sub-piece accuracy would mean mapping characters onto milliseconds, which the audio gives no honest way to do.

## Carried in

| from | what |
|---|---|
| #9 | dictation diagnostics — build, device and OS on every failure; refused permission and no-transcript sessions now reported; microphone proven before a token is bought |
| #8 | daily credit engine client — inert until the server switch is on |

`versionCode` 820.

## Not verified

The remote read-aloud path has not run on a device. `dart analyze` is clean and the fallback is written to leave nothing playing, but pause, resume and seek across pieces are exactly the kind of thing that needs a real message and a real thumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)