### PR TITLE
fix: harden purchase processing, cancellation handling, and chat credentials

### DIFF
--- a/lib/chat/services/api.dart
+++ b/lib/chat/services/api.dart
@@ -36,13 +36,15 @@ class ApiService {
 
   final Dio _dio;
   CancelToken? _cancelToken;
-  String? _cachedToken;
+  final FirebaseAuth _auth;
 
-  ApiService()
-      : _dio = Dio(BaseOptions(
-          connectTimeout: const Duration(seconds: 20),
-          receiveTimeout: const Duration(minutes: 5),
-        ));
+  ApiService({FirebaseAuth? auth, Dio? dio})
+      : _auth = auth ?? FirebaseAuth.instance,
+        _dio = dio ??
+            Dio(BaseOptions(
+              connectTimeout: const Duration(seconds: 20),
+              receiveTimeout: const Duration(minutes: 5),
+            ));
 
   // PERF: Reuse a single Dio instance for title generation to avoid
   // creating a new HTTP connection pool on every new conversation.
@@ -81,13 +83,33 @@ class ApiService {
   }) async {
     _cancelToken = CancelToken();
 
-    final user = FirebaseAuth.instance.currentUser;
+    final user = _auth.currentUser;
     if (user == null) {
       throw ApiException(localizations.errorUserNotAuthenticated,
           statusCode: 401, code: 'NO_USER');
     }
 
+    void ensureCurrentUser() {
+      if (_auth.currentUser?.uid != user.uid) {
+        throw ApiException(localizations.errorUserNotAuthenticated,
+            statusCode: 401, code: 'USER_CHANGED');
+      }
+    }
+
+    Future<String> requestToken({bool forceRefresh = false}) async {
+      ensureCurrentUser();
+      // Firebase owns token caching and expiry; never share a token across users.
+      final token = await user.getIdToken(forceRefresh);
+      ensureCurrentUser();
+      if (token == null || token.isEmpty) {
+        throw ApiException(localizations.errorUserNotAuthenticated,
+            statusCode: 401, code: 'NO_TOKEN');
+      }
+      return token;
+    }
+
     Future<String> attemptRequest(String token, String targetModel) async {
+      ensureCurrentUser();
       final completer = Completer<String>();
       final finalContent = StringBuffer();
       String currentEvent = '';
@@ -670,12 +692,12 @@ class ApiService {
     }
 
     try {
-      _cachedToken ??= await user.getIdToken(false);
-      return await attemptRequestWithFailover(_cachedToken!);
+      final token = await requestToken();
+      return await attemptRequestWithFailover(token);
     } on DioException catch (e) {
       if (e.response?.statusCode == 401 || e.response?.statusCode == 403) {
-        _cachedToken = await user.getIdToken(true);
-        return await attemptRequestWithFailover(_cachedToken!);
+        final token = await requestToken(forceRefresh: true);
+        return await attemptRequestWithFailover(token);
       }
       if (e.type == DioExceptionType.cancel) throw UserCancelledException();
       throw ApiException(localizations.errorNetwork, code: 'CONNECTION_ERROR');
@@ -742,7 +764,7 @@ class ApiService {
   /// Silently generates a title for a new conversation using the backend's fast new title endpoint.
   Future<String?> optimizeImagePrompt(String userInput) async {
     try {
-      final user = FirebaseAuth.instance.currentUser;
+      final user = _auth.currentUser;
       if (user == null) return null;
       final String? token = await user.getIdToken();
 
@@ -795,7 +817,7 @@ class ApiService {
     try {
       debugPrint(
           '[TitleGen] 🚀 Starting title generation for: "${userInput.length > 20 ? userInput.substring(0, 20) : userInput}..."');
-      final user = FirebaseAuth.instance.currentUser;
+      final user = _auth.currentUser;
       if (user == null) {
         debugPrint('[TitleGen] ❌ Error: User is null');
         return null;
@@ -862,7 +884,7 @@ class ApiService {
   Future<List<String>?> extractUserMemory(
       String userInput, String langCode) async {
     try {
-      final user = FirebaseAuth.instance.currentUser;
+      final user = _auth.currentUser;
       if (user == null) return null;
 
       final String? token = await user.getIdToken();

--- a/lib/funds/backend/purchase.dart
+++ b/lib/funds/backend/purchase.dart
@@ -2,7 +2,7 @@ part of 'service.dart';
 
 extension FundsPurchase on FundsBackend {
   Future<void> purchase(ProductDetails product) async {
-    if (_isPurchasePending) {
+    if (isPurchasePending) {
       log('Purchase attempt ignored: Another purchase is already pending.',
           name: FundsBackend._logName);
       return;
@@ -88,53 +88,46 @@ extension FundsPurchase on FundsBackend {
 
         ChangeSubscriptionParam? changeParam;
 
-        if (_activeSubscriptionProductId != null &&
-            _activeSubscriptionProductId!.isNotEmpty) {
-          log('Detected active subscription: $_activeSubscriptionProductId. Attempting upgrade flow.',
-              name: FundsBackend._logName);
-
-          GooglePlayPurchaseDetails? oldPurchase;
-
-          try {
-            final androidAddition = _inAppPurchase
-                .getPlatformAddition<InAppPurchaseAndroidPlatformAddition>();
-            final QueryPurchaseDetailsResponse pastPurchasesResponse =
-                await androidAddition.queryPastPurchases();
-
-            if (pastPurchasesResponse.error == null) {
-              try {
-                oldPurchase = pastPurchasesResponse.pastPurchases
-                    .map((e) => e)
-                    .firstWhere((p) =>
-                        p.productID == _activeSubscriptionProductId &&
-                        p.status == PurchaseStatus.purchased);
-              } catch (_) {}
-            }
-          } catch (e) {
-            log('Failed to query past purchases for upgrade flow: $e',
-                name: FundsBackend._logName);
+        // Always consult the store, even before the user document has loaded.
+        // Do not start a second subscription while ownership is uncertain.
+        try {
+          final android = _inAppPurchase
+              .getPlatformAddition<InAppPurchaseAndroidPlatformAddition>();
+          final owned = await android.queryPastPurchases();
+          if (owned.error != null) {
+            throw StateError('Store ownership query failed');
           }
-
-          if (oldPurchase != null) {
-            log('Found old purchase token. Configuring replacement mode (Upgrade).',
-                name: FundsBackend._logName);
+          final subscriptions = owned.pastPurchases
+              .where((p) => FundsBackend._subscriptionIds.contains(p.productID))
+              .toList();
+          if (subscriptions.length > 1 ||
+              subscriptions.any((p) => p.status != PurchaseStatus.purchased)) {
+            throw StateError('Subscription ownership needs reconciliation');
+          }
+          if (subscriptions.isEmpty) {
+            if (_activeSubscriptionProductId?.isNotEmpty == true) {
+              throw StateError('Store and account subscription disagree');
+            }
+          } else {
+            final oldPurchase = subscriptions.single;
+            if (oldPurchase.productID == googlePlayProductDetails.id) {
+              throw StateError('Subscription already owned');
+            }
             changeParam = ChangeSubscriptionParam(
               oldPurchaseDetails: oldPurchase,
               replacementMode: ReplacementMode.withTimeProration,
             );
-          } else {
-            log('CRITICAL: Sync mismatch. DB says active sub, but local store has no token. Blocking to prevent double billing.',
-                name: FundsBackend._logName);
-
-            _notificationService?.showNotification(
-              message:
-                  "Please tap 'Restore Purchases' first to sync your account.",
-              type: NotificationType.error,
-              oneLine: false,
-            );
-            _setPurchasePending(false);
-            return;
           }
+        } catch (e) {
+          log('Subscription purchase requires restore: $e',
+              name: FundsBackend._logName);
+          _notificationService?.showNotification(
+            message: 'Please tap "Restore Purchases" first to sync your account.',
+            type: NotificationType.error,
+            oneLine: false,
+          );
+          _setPurchasePending(false);
+          return;
         }
 
         purchaseParam = GooglePlayPurchaseParam(
@@ -157,11 +150,20 @@ extension FundsPurchase on FundsBackend {
     }
 
     try {
-      if (FundsBackend._subscriptionIds.contains(product.id)) {
-        await _inAppPurchase.buyNonConsumable(purchaseParam: purchaseParam);
-      } else {
-        await _inAppPurchase.buyConsumable(purchaseParam: purchaseParam);
+      if (_auth.currentUser?.uid != user.uid) {
+        _setPurchasePending(false);
+        return;
       }
+      final bool started;
+      if (FundsBackend._subscriptionIds.contains(product.id)) {
+        started = await _inAppPurchase.buyNonConsumable(purchaseParam: purchaseParam);
+      } else {
+        started = await _inAppPurchase.buyConsumable(
+          purchaseParam: purchaseParam,
+          autoConsume: defaultTargetPlatform != TargetPlatform.android,
+        );
+      }
+      if (!started) _setPurchasePending(false);
     } catch (e, stack) {
       log('Error initiating purchase flow: $e',
           name: FundsBackend._logName, error: e);
@@ -204,7 +206,7 @@ extension FundsPurchase on FundsBackend {
   }
 
   Future<void> restorePurchases() async {
-    if (_isPurchasePending) return;
+    if (isPurchasePending) return;
     _setPurchasePending(true);
 
     try {
@@ -212,7 +214,7 @@ extension FundsPurchase on FundsBackend {
       await _inAppPurchase.restorePurchases();
 
       Future.delayed(const Duration(seconds: 4), () {
-        if (_isPurchasePending) {
+        if (isPurchasePending) {
           log('Restore timeout. Resetting UI.', name: FundsBackend._logName);
           _setPurchasePending(false);
         }

--- a/lib/funds/backend/purchase.dart
+++ b/lib/funds/backend/purchase.dart
@@ -275,10 +275,8 @@ extension FundsPurchase on FundsBackend {
       oneLine: false,
     );
 
-    if (purchaseDetails.pendingCompletePurchase) {
-      _inAppPurchase.completePurchase(purchaseDetails);
-    }
-
+    // Never finalize an error update as delivered. Only purchased/restored
+    // transactions are eligible for server verification and completion.
     _setPurchasePending(false);
   }
 
@@ -294,7 +292,9 @@ extension FundsPurchase on FundsBackend {
   }
 
   void _handleCanceledPurchase(PurchaseDetails d) {
-    if (d.pendingCompletePurchase) _inAppPurchase.completePurchase(d);
+    // A canceled store flow is not a delivered purchase. In particular, do
+    // not call completePurchase here even if a platform wrapper reports a
+    // pending completion flag.
     _setPurchasePending(false);
   }
 }

--- a/lib/funds/backend/service.dart
+++ b/lib/funds/backend/service.dart
@@ -14,6 +14,7 @@ import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:in_app_purchase_android/in_app_purchase_android.dart';
 import 'package:in_app_purchase_storekit/store_kit_wrappers.dart';
 import '../../cache.dart';
+import 'transaction_guard.dart';
 import '../../internet.dart';
 import '../../l10n/app_localizations.dart';
 import '../../notifications/introvert.dart';
@@ -44,6 +45,7 @@ class FundsBackend with ChangeNotifier {
 
   bool _isLoading = true;
   bool _isPurchasePending = false;
+  final TransactionGuard _verificationGuard = TransactionGuard();
   String? _errorMessage;
   List<ProductDetails> _products = [];
   int _currentUserSubscriptionLevel = 0;
@@ -60,7 +62,8 @@ class FundsBackend with ChangeNotifier {
 
   bool get isLoading => _isLoading;
 
-  bool get isPurchasePending => _isPurchasePending;
+  bool get isPurchasePending =>
+      _isPurchasePending || _verificationGuard.isBusy;
 
   String? get errorMessage => _errorMessage;
 

--- a/lib/funds/backend/transaction_guard.dart
+++ b/lib/funds/backend/transaction_guard.dart
@@ -1,0 +1,16 @@
+/// Suppresses overlapping delivery attempts for the same store transaction.
+/// This is not a replacement for a durable, idempotent server-side ledger.
+class TransactionGuard {
+  final Set<String> _active = {};
+
+  bool get isBusy => _active.isNotEmpty;
+
+  Future<void> run(String key, Future<void> Function() action) async {
+    if (!_active.add(key)) return;
+    try {
+      await action();
+    } finally {
+      _active.remove(key);
+    }
+  }
+}

--- a/lib/funds/backend/verification.dart
+++ b/lib/funds/backend/verification.dart
@@ -3,6 +3,25 @@ part of 'service.dart';
 extension FundsVerification on FundsBackend {
   Future<void> _verifyAndCompletePurchase(
       PurchaseDetails purchaseDetails) async {
+    // A store may replay the same purchase while verification is still pending.
+    final receipt = purchaseDetails.verificationData.serverVerificationData;
+    final key = '${purchaseDetails.productID}:'
+        '${purchaseDetails.purchaseID ?? receipt}';
+    try {
+      await _verificationGuard.run(key, () async {
+        if (_disposed || _auth.currentUser == null) return;
+        _notify();
+        await _processPurchase(purchaseDetails);
+      });
+    } catch (e, stack) {
+      await _crashlytics.recordError(e, stack,
+          reason: 'Purchase processing failed', fatal: false);
+    } finally {
+      if (!_disposed) _notify();
+    }
+  }
+
+  Future<void> _processPurchase(PurchaseDetails purchaseDetails) async {
     String? verificationData;
 
     if (defaultTargetPlatform == TargetPlatform.iOS) {
@@ -61,7 +80,17 @@ extension FundsVerification on FundsBackend {
         'transactionId': purchaseDetails.purchaseID,
       });
 
-      if (purchaseDetails.pendingCompletePurchase) {
+      // Do not consume Android credits until server verification has succeeded.
+      if (defaultTargetPlatform == TargetPlatform.android &&
+          !FundsBackend._subscriptionIds.contains(purchaseDetails.productID)) {
+        final android = _inAppPurchase
+            .getPlatformAddition<InAppPurchaseAndroidPlatformAddition>();
+        final result = await android.consumePurchase(purchaseDetails);
+        if (result.responseCode != BillingResponse.ok) {
+          throw StateError('Could not consume verified purchase: '
+              '${result.responseCode}');
+        }
+      } else if (purchaseDetails.pendingCompletePurchase) {
         await _inAppPurchase.completePurchase(purchaseDetails);
       }
 
@@ -100,25 +129,13 @@ extension FundsVerification on FundsBackend {
       log('Verification failed: ${e.message} (Code: ${e.code})',
           name: FundsBackend._logName);
 
-      if (e.code == 'invalid-argument' ||
-          e.code == 'not-found' ||
-          e.code == 'already-exists') {
-        log('Fatal error. Clearing from queue.', name: FundsBackend._logName);
-        if (purchaseDetails.pendingCompletePurchase) {
-          await _inAppPurchase.completePurchase(purchaseDetails);
-        }
-        _notificationService?.showNotification(
-          message: _localizations?.purchaseError ?? 'purchaseError',
-          type: NotificationType.error,
-          oneLine: false,
-        );
-      } else {
-        _notificationService?.showNotification(
-          message: _localizations?.verificationDelayed ?? 'verificationDelayed',
-          type: NotificationType.error,
-          oneLine: false,
-        );
-      }
+      // A generic error code does not prove that entitlement was delivered.
+      // Keep the transaction recoverable until the server confirms success.
+      _notificationService?.showNotification(
+        message: _localizations?.verificationDelayed ?? 'verificationDelayed',
+        type: NotificationType.error,
+        oneLine: false,
+      );
 
       await _crashlytics.recordError(e, stack,
           reason: 'Server returned HttpsError for ${purchaseDetails.productID}',

--- a/lib/funds/backend/verification.dart
+++ b/lib/funds/backend/verification.dart
@@ -3,15 +3,20 @@ part of 'service.dart';
 extension FundsVerification on FundsBackend {
   Future<void> _verifyAndCompletePurchase(
       PurchaseDetails purchaseDetails) async {
+    final expectedUid = _auth.currentUser?.uid;
+    if (expectedUid == null) return;
+
     // A store may replay the same purchase while verification is still pending.
+    // Scope the guard to the account that started verification so an auth switch
+    // cannot make a callback look like it belongs to the newly signed-in user.
     final receipt = purchaseDetails.verificationData.serverVerificationData;
-    final key = '${purchaseDetails.productID}:'
+    final key = '$expectedUid:${purchaseDetails.productID}:'
         '${purchaseDetails.purchaseID ?? receipt}';
     try {
       await _verificationGuard.run(key, () async {
-        if (_disposed || _auth.currentUser == null) return;
+        if (_disposed || _auth.currentUser?.uid != expectedUid) return;
         _notify();
-        await _processPurchase(purchaseDetails);
+        await _processPurchase(purchaseDetails, expectedUid);
       });
     } catch (e, stack) {
       await _crashlytics.recordError(e, stack,
@@ -21,8 +26,16 @@ extension FundsVerification on FundsBackend {
     }
   }
 
-  Future<void> _processPurchase(PurchaseDetails purchaseDetails) async {
+  Future<void> _processPurchase(
+      PurchaseDetails purchaseDetails, String expectedUid) async {
     String? verificationData;
+
+    if (_auth.currentUser?.uid != expectedUid) {
+      log('Purchase verification skipped because the signed-in account changed.',
+          name: FundsBackend._logName);
+      _setPurchasePending(false);
+      return;
+    }
 
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       verificationData = await _resolveIosReceiptBase64(purchaseDetails);
@@ -71,8 +84,16 @@ extension FundsVerification on FundsBackend {
     }
 
     try {
+      // Re-check immediately before the callable so a queued purchase callback
+      // cannot be verified against a different Firebase account.
+      if (_auth.currentUser?.uid != expectedUid) {
+        log('Purchase verification aborted after an account switch.',
+            name: FundsBackend._logName);
+        return;
+      }
+
       final callable = _functions.httpsCallable('verifyPurchase');
-      await callable.call<dynamic>({
+      final result = await callable.call<dynamic>({
         'receiptData': verificationData,
         'productId': purchaseDetails.productID,
         'platform': defaultTargetPlatform == TargetPlatform.iOS ? 'ios' : 'android',
@@ -80,21 +101,35 @@ extension FundsVerification on FundsBackend {
         'transactionId': purchaseDetails.purchaseID,
       });
 
-      // Do not consume Android credits until server verification has succeeded.
-      if (defaultTargetPlatform == TargetPlatform.android &&
-          !FundsBackend._subscriptionIds.contains(purchaseDetails.productID)) {
-        final android = _inAppPurchase
-            .getPlatformAddition<InAppPurchaseAndroidPlatformAddition>();
-        final result = await android.consumePurchase(purchaseDetails);
-        if (result.responseCode != BillingResponse.ok) {
-          throw StateError('Could not consume verified purchase: '
-              '${result.responseCode}');
-        }
-      } else if (purchaseDetails.pendingCompletePurchase) {
+      // A resolved callable is not automatically a successful purchase. Require
+      // the backend's explicit success contract before store finalization or UI.
+      final data = result.data;
+      if (data is! Map || data['success'] != true) {
+        throw StateError('verifyPurchase returned no explicit success result');
+      }
+
+      final isAndroidConsumable =
+          defaultTargetPlatform == TargetPlatform.android &&
+              !FundsBackend._subscriptionIds.contains(purchaseDetails.productID);
+
+      if (!isAndroidConsumable && purchaseDetails.pendingCompletePurchase) {
+        // Android consumables are consumed by Fulcrum after verification. Do not
+        // race the secure backend with a second client-side consume/ack request.
+        // Subscriptions and Apple purchases still need normal store completion.
         await _inAppPurchase.completePurchase(purchaseDetails);
       }
 
       AppDataState().markUserDataAsChanged();
+
+      // If the account changed while the server call was in flight, the server
+      // still delivered to the account whose auth token made the request. Store
+      // finalization above is therefore valid, but success UI must not leak into
+      // the newly signed-in account.
+      if (_auth.currentUser?.uid != expectedUid) {
+        log('Purchase verified for the previous account; suppressing success UI.',
+            name: FundsBackend._logName);
+        return;
+      }
 
       // Only fire the purchase-completed event for genuinely fresh
       // transactions (within the last 5 minutes).  Google Play's

--- a/test/api_auth_test.dart
+++ b/test/api_auth_test.dart
@@ -1,0 +1,118 @@
+import 'package:cortex/chat/services/api.dart';
+import 'package:cortex/l10n/app_localizations_en.dart';
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class TestAuth extends Fake implements FirebaseAuth {
+  User? user;
+  @override
+  User? get currentUser => user;
+}
+
+class TestUser extends Fake implements User {
+  TestUser(this.uid, this.readToken);
+  @override
+  final String uid;
+  final Future<String?> Function(bool) readToken;
+  @override
+  Future<String?> getIdToken([bool forceRefresh = false]) =>
+      readToken(forceRefresh);
+}
+
+void main() {
+  late TestAuth auth;
+  late Dio dio;
+  late ApiService api;
+  late List<String?> headers;
+  late int responseStatus;
+
+  setUp(() {
+    auth = TestAuth();
+    headers = [];
+    responseStatus = 400;
+    dio = Dio();
+    dio.interceptors.add(InterceptorsWrapper(onRequest: (options, handler) {
+      headers.add(options.headers['Authorization'] as String?);
+      // Stop at the transport boundary: never contact the production backend.
+      handler.reject(DioException(
+        requestOptions: options,
+        type: DioExceptionType.badResponse,
+        response: Response(requestOptions: options, statusCode: responseStatus),
+      ));
+    }));
+    api = ApiService(auth: auth, dio: dio);
+  });
+
+  tearDown(() => dio.close(force: true));
+
+  Future<String> request() => api.getCharacterResponse(
+        userInput: 'test',
+        context: [],
+        characterId: 'test',
+        isPremium: false,
+        baseModelId: 'test',
+        localizations: AppLocalizationsEn(),
+      );
+
+  Future<void> rejectedRequest() async {
+    await expectLater(request(), throwsA(isA<ApiException>()));
+  }
+
+  test('a reused service obtains the active account token on each request', () async {
+    auth.user = TestUser('a', (_) async => 'token-a');
+    await rejectedRequest();
+    auth.user = TestUser('b', (_) async => 'token-b');
+    await rejectedRequest();
+    expect(headers, ['Bearer token-a', 'Bearer token-b']);
+  });
+
+  test('uses renewed SDK tokens for the same account', () async {
+    var token = 'first';
+    auth.user = TestUser('a', (_) async => token);
+    await rejectedRequest();
+    token = 'renewed';
+    await rejectedRequest();
+    expect(headers, ['Bearer first', 'Bearer renewed']);
+  });
+
+  test('missing tokens never reach the transport', () async {
+    for (final token in <String?>[null, '']) {
+      auth.user = TestUser('a', (_) async => token);
+      await rejectedRequest();
+    }
+    expect(headers, isEmpty);
+  });
+
+  test('account switch during token lookup aborts before sending', () async {
+    auth.user = TestUser('a', (_) async {
+      auth.user = TestUser('b', (_) async => 'token-b');
+      return 'token-a';
+    });
+    await expectLater(request(), throwsA(isA<ApiException>().having(
+      (e) => e.code, 'code', 'USER_CHANGED')));
+    expect(headers, isEmpty);
+  });
+
+  test('logout during token lookup aborts before sending', () async {
+    auth.user = TestUser('a', (_) async {
+      auth.user = null;
+      return 'token-a';
+    });
+    await rejectedRequest();
+    expect(headers, isEmpty);
+  });
+
+  test('401 retry refreshes only the original active account', () async {
+    responseStatus = 401;
+    final refreshes = <bool>[];
+    auth.user = TestUser('a', (refresh) async {
+      refreshes.add(refresh);
+      if (refresh) auth.user = TestUser('b', (_) async => 'token-b');
+      return 'token-a';
+    });
+    await rejectedRequest();
+    expect(refreshes, [false, true]);
+    expect(headers, ['Bearer token-a']);
+  });
+}

--- a/test/payment_transaction_guard_test.dart
+++ b/test/payment_transaction_guard_test.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+import 'package:cortex/funds/backend/transaction_guard.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('overlapping callbacks for one purchase run once', () async {
+    final guard = TransactionGuard();
+    final pending = Completer<void>();
+    var calls = 0;
+    final first = guard.run('purchase-a', () async {
+      calls++;
+      await pending.future;
+    });
+    await guard.run('purchase-a', () async { calls++; });
+    expect(calls, 1);
+    expect(guard.isBusy, isTrue);
+    pending.complete();
+    await first;
+    expect(guard.isBusy, isFalse);
+  });
+
+  test('a failed verification can be retried', () async {
+    final guard = TransactionGuard();
+    await expectLater(guard.run('purchase-a', () async {
+      throw StateError('network unavailable');
+    }), throwsStateError);
+    var retried = false;
+    await guard.run('purchase-a', () async { retried = true; });
+    expect(retried, isTrue);
+    expect(guard.isBusy, isFalse);
+  });
+
+  test('different purchases remain independently protected', () async {
+    final guard = TransactionGuard();
+    final pending = Completer<void>();
+    final first = guard.run('purchase-a', () => pending.future);
+    var secondRan = false;
+    await guard.run('purchase-b', () async { secondRan = true; });
+    expect(secondRan, isTrue);
+    expect(guard.isBusy, isTrue);
+    pending.complete();
+    await first;
+    expect(guard.isBusy, isFalse);
+  });
+}


### PR DESCRIPTION
Payment processing could consume/finalize transactions before the server had durably accepted them, finish canceled/error updates, overlap verification for the same purchase, and miss existing subscriptions when cached account metadata was empty.

## Billing changes
- Disable Android automatic consumption. Fulcrum is the single authority that verifies and consumes Android consumables; Cortex no longer races it with a second client-side consume.
- Never call `completePurchase` for `PurchaseStatus.error` or `PurchaseStatus.canceled`. Only `purchased` / `restored` updates enter verification/finalization.
- Require the `verifyPurchase` callable to resolve with an explicit `{ success: true }` result before store finalization or success UI. A resolved callable without this contract is treated as a failed verification.
- Keep purchased/restored transactions unfinished on Firebase verification errors. An error does not prove entitlement delivery.
- Bind in-flight verification to the Firebase UID that received the callback; abort before verification if the account changed and suppress success UI if it changes while the server call is in flight.
- Suppress overlapping verification by account + product + transaction/receipt identity; allow later retries after failure. Busy UI includes active verifications.
- Always query Android store ownership before a subscription purchase. Existing purchases are passed through the replacement flow; ambiguous ownership, query failures, and already-owned identical products require reconciliation instead of initiating another purchase.
- Recheck the account before opening billing and release the pending state when the store declines to start.

The earlier online-chat fix remains: delegate ID token caching to Firebase and reject account changes during token lookup/retry. Local model storage, history, native project structure, dependencies and UI layout are unchanged.

## Fulcrum contract reviewed from the supplied checkout
The supplied Fulcrum checkout was inspected alongside `architecture/cortex/payments.md` and `architecture/fulcrum/billing.md`. A separate backend patch was prepared because the connected GitHub installation does not expose the Fulcrum repository.

Backend patch fixes include:
- Do not let definitive Google SubscriptionPurchaseV2 rejections fall through to legacy verification; pending-canceled/expired/product-mismatch states remain terminal.
- Do not let definitive StoreKit 2 revocation/refund/product-mismatch results fall through to an older legacy receipt.
- Keep Android consumable verification/consumption server-side and enforce account binding when the provider supplies `obfuscatedExternalAccountId`.
- Correct Google RTDN notification type handling (including `4 = SUBSCRIPTION_PURCHASED`, `13 = SUBSCRIPTION_EXPIRED`, `20 = SUBSCRIPTION_PENDING_PURCHASE_CANCELED`) and use Pub/Sub event/message identity rather than a nonexistent notification payload ID.
- Resolve subscription product/order/state from SubscriptionPurchaseV2 line items instead of relying on fields absent/deprecated in current RTDN/V2 payloads.
- Treat a canceled pending one-time purchase as canceled, not as a refund.
- Prevent renewal/recovery webhook replays from repeatedly awarding initial purchase bonuses.
- Do not silently mark provider/transaction failures as processed; retryable backend failures surface so Pub/Sub can retry.

Apple notification JWS cryptographic verification is intentionally not faked in this patch: the supplied lifecycle currently decodes signed data without validating its certificate chain. Production hardening should use Apple's official App Store Server Library with Apple root certificates and the correct production app metadata.

## Validation
- Cortex: latest branch changes were re-read after upload. GitHub currently reports no status checks/workflow runs for the latest commit, so no CI pass is claimed.
- Existing TransactionGuard regression tests cover duplicate callbacks, retry after failure, and independent transactions.
- Fulcrum patch: `node --check` passed for `iap.js`, `helpers.js`, `android/lifecycle.js`, and `ios/lifecycle.js`; `git diff --check` passed; targeted static assertions cover RTDN purchased/expired/pending-cancel mappings, event-id idempotency, terminal V2/SK2 errors, explicit success response, bonus replay prevention, and provider account binding.
- Flutter/Dart SDK and a real Play/StoreKit sandbox were not available here; no production purchase or deployment was triggered.

## Required before merge/release
Run Flutter analysis/tests in the full checkout and exercise Play/StoreKit sandbox cases: user cancellation, payment decline, PENDING -> PURCHASED, pending purchase cancellation, restore/replay, network failure after store payment, repeated callbacks, account switch during verification, subscription renewal/cancellation/expiry/refund/revoke, and consumable purchase/consume. Deploy the matching Fulcrum patch before/with this client change so the `{ success: true }` contract and server-owned Android consumption are consistent.