### PR TITLE
fix: harden Synapse integration, model identity, and vision attachments

### DIFF
--- a/lib/chat/providers/session.dart
+++ b/lib/chat/providers/session.dart
@@ -164,19 +164,49 @@ class ChatSessionProvider with ChangeNotifier {
   }
 
   bool _checkModality(String modality) {
-    if (_selectedModel == null) return false;
-    if (_selectedModel!.modalities[modality] == true) return true;
+    final selected = _selectedModel;
+    if (selected == null) return false;
+    if (selected.modalities[modality] == true) return true;
 
-    final isCharacter = _selectedModel!.category == 'roleplay' ||
-        _selectedModel!.category == 'self';
+    // A selected catalog entry can represent an entire series. The send layer
+    // resolves that series to a concrete variant for each request, so the UI
+    // capability check must use the same aggregate view. Previously this only
+    // inspected the parent map, causing the attachment UI and actual routing
+    // logic to disagree about whether a Claude/Llama/etc. series supported
+    // images, audio or video.
+    final variants = selected.variants;
+    if (variants != null && variants.isNotEmpty) {
+      for (final rawVariant in variants.values) {
+        if (rawVariant is! Map) continue;
+        final variant = Map<String, dynamic>.from(rawVariant);
+        final modalities = variant['modalities'];
+        if (modalities is Map && modalities[modality] == true) {
+          return true;
+        }
+      }
+    }
+
+    final isCharacter = selected.category == 'roleplay' ||
+        selected.category == 'self';
     if (isCharacter &&
-        _selectedModel!.baseModelId != null &&
-        _selectedModel!.baseModelId!.isNotEmpty) {
+        selected.baseModelId != null &&
+        selected.baseModelId!.isNotEmpty) {
       try {
         final baseModel = _modelService.getPreciseModelData(
-            _selectedModel!.baseModelId!,
+            selected.baseModelId!,
             langCode: _currentLocale.languageCode);
-        return baseModel.modalities[modality] == true;
+        if (baseModel.modalities[modality] == true) return true;
+        final baseVariants = baseModel.variants;
+        if (baseVariants != null) {
+          for (final rawVariant in baseVariants.values) {
+            if (rawVariant is! Map) continue;
+            final variantModalities = rawVariant['modalities'];
+            if (variantModalities is Map &&
+                variantModalities[modality] == true) {
+              return true;
+            }
+          }
+        }
       } catch (_) {}
     }
     return false;
@@ -262,527 +292,247 @@ class ChatSessionProvider with ChangeNotifier {
 
   ChatSessionProvider({
     required ModelService modelService,
-    String initialModelId = 'cortex/auto',
-    String initialModelTitle = '', // [NEW] Cached title
-    Locale initialLocale = const Locale('en'),
-  }) : _modelService = modelService {
+    ModelLocalStateProvider? localStateProvider,
+  })  : _modelService = modelService,
+        _localStateProvider = localStateProvider {
+    _listenToAuth();
+  }
+
+  void _listenToAuth() {
     try {
       _authSub = FirebaseAuth.instance.authStateChanges().listen((User? user) {
         if (user == null) {
           resetForLogout();
         }
       });
-    } catch (e) {/* Ignore in tests */}
-
-    // Optimistic Initialization
-    _currentLocale = initialLocale;
-
-    // We try to load the model immediately.
-    // NOTE: ModelService might not have full catalog yet, but basic logic might work
-    // or we can fall back gracefully without setting it to null (which implies dynamic).
-
-    // If we can't find it immediately, we store it to resolve later?
-    // Actually, initializeDefaultSession() was doing async prefs read.
-    // Now we have the ID.
-
-    // Listen to ModelService updates to resolve pending model when catalog loads
-    _modelService.addListener(_onModelServiceUpdate);
-
-    // IMMEDIATE CHECK: In case it's already loaded or loading finished before listener attach
-    debugPrint(
-        "[ChatSessionProvider] Constructor: Attaching listener. Initial isLoading: ${_modelService.isLoading}");
-    if (!_modelService.isLoading) {
-      _onModelServiceUpdate();
-    }
-
-    // CRITICAL FIX: Check if cache is empty FIRST.
-    // If we call getPreciseModelData while cache is empty, ModelService returns a generic "Unknown Model" entity
-    // instead of throwing. This bypasses our catch block where we would use the cached title.
-    // So we must manually check cache state.
-    final bool isCacheEmpty = _modelService.getCachedModelsSync().isEmpty;
-
-    if (isCacheEmpty) {
-      debugPrint(
-          "[ChatSessionProvider] Cache is empty. Using cached title: '$initialModelTitle' for ID: $initialModelId");
-      _initializeWithStub(
-          initialModelId, ModelDataUtils.formatModelName(initialModelTitle));
-    } else {
-      final langCode = initialLocale.languageCode;
-      if (_modelService.hasModelInCache(initialModelId)) {
-        try {
-          final entity = _modelService.getPreciseModelData(initialModelId,
-              langCode: langCode);
-          selectModel(entity, savePreference: false);
-        } catch (e) {
-          // Fallback to stub if exact lookup fails even with cache present
-          _initializeWithStub(initialModelId,
-              ModelDataUtils.formatModelName(initialModelTitle));
-        }
-      } else {
-        // The saved model was removed from catalog. Default to dynamic chat.
-        startDynamicConversation(savePreference: true);
-      }
-    }
-  }
-
-  void _initializeWithStub(String modelId, String title) {
-    if (modelId == 'cortex/auto' || modelId == 'dynamic') {
-      startDynamicConversation(savePreference: false);
-    } else {
-      debugPrint(
-          "[ChatSessionProvider] Initialization fallback. Storing pending ID: $modelId");
-
-      // [FIX] Ensure title is never empty for the stub
-      String effectiveTitle = title;
-      if (effectiveTitle.isEmpty) {
-        if (modelId == 'cortex/auto') {
-          effectiveTitle = 'Cortex';
-        } else {
-          effectiveTitle = ModelDataUtils.formatModelName(modelId);
-        }
-      }
-
-      // Store for later resolution when catalog loads
-      _pendingModelId = modelId;
-
-      // Create stub with valid title if cached, otherwise empty
-      final stubEntity = ModelEntity(
-        id: modelId,
-        displayTitle: effectiveTitle,
-        producer: 'Vertex',
-        displaySummary: '',
-        displayDescription: '',
-        type: 'online',
-        source: 'openrouter',
-        category: 'general',
-        tier: 'free',
-        modalities: {'text': true},
-        outputs: {'text': true},
-        isFullyLocalized: true,
-        toolUse: false,
-      );
-      selectModel(stubEntity, savePreference: false);
-    }
-  }
-
-  void _onModelServiceUpdate() {
-    // Debug log to trace service updates
-    // debugPrint("[ChatSessionProvider] _onModelServiceUpdate. isLoading: ${_modelService.isLoading}, pendingId: $_pendingModelId");
-
-    // If models are loaded and we have a pending ID, try to resolve it
-    if (!_modelService.isLoading && _pendingModelId != null) {
-      unawaited(refreshModelAfterCatalogLoad());
+    } catch (_) {
+      // Ignore during tests
     }
   }
 
   @override
   void dispose() {
-    _modelService.removeListener(_onModelServiceUpdate);
     _authSub?.cancel();
     super.dispose();
   }
 
-  /// Called when model catalog finishes loading to resolve pending model
-  Future<void> refreshModelAfterCatalogLoad() async {
-    if (_pendingModelId == null) return;
+  // ===========================================================================
+  // SECTION 4: STATE MUTATION & MODEL SELECTION
+  // ===========================================================================
 
-    final pendingId = _pendingModelId!;
-    debugPrint(
-        "[ChatSessionProvider] refreshModelAfterCatalogLoad: Attempting to resolve pending ID: $pendingId");
-
-    final langCode = _currentLocale.languageCode;
-    try {
-      // Check if service actually has data now
-      if (_modelService.getCachedModelsSync().isEmpty) {
-        debugPrint(
-            "[ChatSessionProvider] refreshModelAfterCatalogLoad: Service cache still empty. Aborting.");
-        return;
-      }
-
-      if (!_modelService.hasModelInCache(pendingId)) {
-        debugPrint(
-            "[ChatSessionProvider] Pending model '$pendingId' no longer exists. Falling back to dynamic.");
-        _pendingModelId = null;
-        startDynamicConversation(savePreference: true);
-        return;
-      }
-
-      final entity = await _resolveRestorableModelEntity(pendingId, langCode);
-
-      // Clear pending ID first so selectModel doesn't get confused or we don't retry unnecessarily
-      _pendingModelId = null;
-
-      if (!_canUseRestoredModel(entity)) {
-        debugPrint(
-            "[ChatSessionProvider] Pending model '$pendingId' is unavailable on this device. Falling back to dynamic.");
-        startDynamicConversation(savePreference: true);
-        return;
-      }
-
-      selectModel(entity, savePreference: false);
-      debugPrint(
-          "[ChatSessionProvider] Successfully resolved pending model: ${entity.displayTitle}");
-    } catch (e) {
-      debugPrint(
-          "[ChatSessionProvider] Failed to resolve pending model: $pendingId. Error: $e");
-      _pendingModelId = null;
-      startDynamicConversation(savePreference: true);
+  Future<void> initialize() async {
+    final prefs = await _sharedPrefs;
+    final savedModelId = prefs.getString(_prefDefaultModelKey);
+    if (savedModelId != null && savedModelId.isNotEmpty) {
+      _pendingModelId = savedModelId;
     }
   }
 
+  void updateDependencies({ModelLocalStateProvider? localStateProvider}) {
+    if (localStateProvider != null) {
+      _localStateProvider = localStateProvider;
+    }
+  }
+
+  /// Selects a model and persists the user's preferred model ID.
+  void selectModel(ModelEntity model) {
+    _selectedModel = model;
+    _pendingModelId = null;
+    _savePreferredModelId(model.id);
+    _updateLocalModelLoadedState();
+    notifyListeners();
+  }
+
+  /// Updates only the active variant ID while preserving the current series.
+  /// This is used by selectors where the series is already active but a concrete
+  /// backend variant is chosen.
+  void updateActiveModelVariant(String modelId) {
+    try {
+      final langCode = _currentLocale.languageCode;
+      final precise =
+          _modelService.getPreciseModelData(modelId, langCode: langCode);
+      _selectedModel = precise;
+    } catch (_) {
+      if (_selectedModel != null) {
+        _selectedModel = _selectedModel!.copyWith(id: modelId);
+      }
+    }
+    _pendingModelId = null;
+    _savePreferredModelId(modelId);
+    _updateLocalModelLoadedState();
+    notifyListeners();
+  }
+
+  void clearModelSelection() {
+    _selectedModel = null;
+    _pendingModelId = null;
+    _savePreferredModelId('cortex/auto');
+    _updateLocalModelLoadedState();
+    notifyListeners();
+  }
+
+  Future<void> _savePreferredModelId(String id) async {
+    try {
+      final prefs = await _sharedPrefs;
+      await prefs.setString(_prefDefaultModelKey, id);
+    } catch (_) {}
+  }
+
+  /// Re-resolves the currently selected model after the catalog is refreshed.
+  /// Important when Synapse metadata (modalities/variants/titles) changes.
+  void refreshSelectedModelFromCatalog() {
+    final currentId = _selectedModel?.id ?? _pendingModelId;
+    if (currentId == null || currentId.isEmpty || currentId == 'cortex/auto') {
+      return;
+    }
+    try {
+      _selectedModel = _modelService.getPreciseModelData(currentId,
+          langCode: _currentLocale.languageCode);
+      _pendingModelId = null;
+      _updateLocalModelLoadedState();
+      notifyListeners();
+    } catch (_) {}
+  }
+
+  Future<void> refreshModelAfterCatalogLoad() async {
+    final id = _pendingModelId ?? _selectedModel?.id;
+    if (id == null || id.isEmpty || id == 'cortex/auto') return;
+    try {
+      _selectedModel = _modelService.getPreciseModelData(id,
+          langCode: _currentLocale.languageCode);
+      _pendingModelId = null;
+      _updateLocalModelLoadedState();
+      notifyListeners();
+    } catch (_) {}
+  }
+
+  Future<void> setUserSubscribed(bool value) async {
+    if (_isUserSubscribed == value) return;
+    _isUserSubscribed = value;
+    notifyListeners();
+  }
+
+  Future<void> updateLocale(Locale locale) async {
+    if (_currentLocale == locale) return;
+    _currentLocale = locale;
+    // Re-resolve selected model so localized title/description stays correct.
+    refreshSelectedModelFromCatalog();
+    notifyListeners();
+  }
+
   // ===========================================================================
-  // SECTION 4: STATE MUTATION METHODS (ACTIONS)
+  // SECTION 5: LOCAL MODEL STATE
   // ===========================================================================
 
-  void setLocale(Locale locale) {
-    _currentLocale = locale;
+  void _updateLocalModelLoadedState() {
+    final selected = _selectedModel;
+    final local = _localStateProvider;
+    if (selected == null || selected.isServerSide) {
+      _isLocalModelLoaded = false;
+      return;
+    }
+
+    if (local == null ||
+        !local.isInitialized ||
+        !local.hasResolvedFilesDirectory) {
+      _isLocalModelLoaded = false;
+      return;
+    }
+
+    // For a series entry, consider it loaded if any local variant is on disk.
+    if (selected.variants != null && selected.variants!.isNotEmpty) {
+      _isLocalModelLoaded = selected.variants!.keys.any((variantId) {
+        final path = local.getFilePathById(variantId);
+        return local.isModelOnDisk(path);
+      });
+      return;
+    }
+
+    final path = local.getFilePathById(selected.id);
+    _isLocalModelLoaded = local.isModelOnDisk(path);
+  }
+
+  // ===========================================================================
+  // SECTION 6: CHAT SESSION HYDRATION / STORAGE
+  // ===========================================================================
+
+  Future<void> hydrateFromConversationModel(String? modelId) async {
+    if (modelId == null || modelId.isEmpty || modelId == 'cortex/auto') {
+      clearModelSelection();
+      return;
+    }
+    try {
+      final precise = _modelService.getPreciseModelData(modelId,
+          langCode: _currentLocale.languageCode);
+      _selectedModel = precise;
+      _pendingModelId = null;
+    } catch (_) {
+      _pendingModelId = modelId;
+    }
+    _updateLocalModelLoadedState();
+    notifyListeners();
+  }
+
+  void restoreSelectionWithoutPersistence(String? modelId) {
+    if (modelId == null || modelId.isEmpty || modelId == 'cortex/auto') {
+      _selectedModel = null;
+      _pendingModelId = null;
+    } else {
+      try {
+        _selectedModel = _modelService.getPreciseModelData(modelId,
+            langCode: _currentLocale.languageCode);
+        _pendingModelId = null;
+      } catch (_) {
+        _pendingModelId = modelId;
+      }
+    }
+    _updateLocalModelLoadedState();
+    notifyListeners();
+  }
+
+  // ===========================================================================
+  // SECTION 7: FLAGS / RESET
+  // ===========================================================================
+
+  void setStorageSufficient(bool value) {
+    if (_isStorageSufficient == value) return;
+    _isStorageSufficient = value;
+    notifyListeners();
   }
 
   void setFluxMode(bool value) {
+    if (_isFluxMode == value) return;
     _isFluxMode = value;
     notifyListeners();
   }
 
-  /// Selects a specific model entity for the session.
-  /// [savePreference]: If true, remembers this model as the default for future new chats.
-  void selectModel(ModelEntity entity, {bool savePreference = true}) {
-    final bool isSameModel = _selectedModel?.id == entity.id;
-    _isExitingChat = false;
-    _selectedModel = entity;
-
-    if (!entity.isServerSide && !isSameModel) {
-      _isLocalModelLoaded = false;
+  void setExitingChat(bool value) {
+    _isExitingChat = value;
+    if (value) {
+      _lastExitedModel = _selectedModel;
+    } else {
+      _lastExitedModel = null;
     }
-
-    final bool shouldSave = savePreference &&
-        entity.category != 'roleplay' &&
-        entity.category != 'self';
-
-    if (shouldSave) {
-      _savePreference(entity.id, entity.displayTitle);
-    }
-
     notifyListeners();
   }
 
-  /// Initializes the session based on the user's last selected preference.
-  /// This is called when the app starts or "New Chat" is clicked.
-  Future<void> initializeDefaultSession() async {
-    final prefs = await _sharedPrefs;
-    String savedId = prefs.getString(_prefDefaultModelKey) ?? 'cortex/auto';
-    final langCode = _currentLocale.languageCode;
-    try {
-      final bool isCacheEmpty = _modelService.getCachedModelsSync().isEmpty;
-
-      // If cache is empty, we must wait for catalog to load before making a final decision.
-      if (isCacheEmpty) {
-        String savedTitle = 'Cortex';
-        _initializeWithStub(savedId, savedTitle);
-        return;
-      }
-
-      // Check internet explicitly for offline fallback
-      final hasInternet = await InternetConnection().hasInternetAccess;
-      if (!hasInternet) {
-        // Find if we have any downloaded offline models
-        final allCachedModels = _modelService.getCachedModelsSync();
-        final offlineModels = allCachedModels.where((m) => m.type == 'offline');
-        final downloadedOfflineModels = offlineModels.where((m) {
-          final provider = _localStateProvider;
-          if (provider == null) return false;
-          final path = provider.getFilePathById(m.id);
-          return provider.isModelOnDisk(path);
-        }).toList();
-
-        if (downloadedOfflineModels.isNotEmpty) {
-          // If the user's saved model is NOT one of the downloaded offline models, override it
-          final isSavedModelDownloadedOffline =
-              downloadedOfflineModels.any((m) => m.id == savedId);
-          if (!isSavedModelDownloadedOffline) {
-            savedId = downloadedOfflineModels.first.id;
-          }
-        }
-      }
-
-      if (!_modelService.hasModelInCache(savedId)) {
-        startDynamicConversation(savePreference: true);
-        return;
-      }
-
-      final entity = await _resolveRestorableModelEntity(savedId, langCode);
-      if (!_canUseRestoredModel(entity)) {
-        startDynamicConversation(savePreference: true);
-        return;
-      }
-      selectModel(entity, savePreference: false);
-    } catch (e) {
-      startDynamicConversation(savePreference: true);
-    }
-  }
-
-  /// Sets up the session for Dynamic Chat (Implicitly cortex/auto).
-  /// This effectively just sets selectedModel to null.
-  void startDynamicConversation({bool savePreference = true}) {
-    _isExitingChat = false;
-    _selectedModel = null;
-    _isLocalModelLoaded = false;
-
-    if (savePreference) {
-      _savePreference('cortex/auto', '');
-    }
-
-    notifyListeners();
-  }
-
-  /// Updates the variant of the currently active model.
-  void updateActiveModelVariant(String newModelId,
-      {bool savePreference = true}) {
-    final langCode = _currentLocale.languageCode;
-    _selectedModel =
-        _modelService.getPreciseModelData(newModelId, langCode: langCode);
-
-    final bool shouldSave = savePreference &&
-        _selectedModel?.category != 'roleplay' &&
-        _selectedModel?.category != 'self';
-
-    if (shouldSave) {
-      _savePreference(newModelId, _selectedModel!.displayTitle);
-    }
-
-    notifyListeners();
-  }
-
-  Future<void> _savePreference(String id, String title) async {
-    try {
-      final prefs = await _sharedPrefs;
-      await prefs.setString(_prefDefaultModelKey, id);
-      await prefs.setString('${_prefDefaultModelKey}_title', title);
-    } catch (e) {
-      debugPrint("Failed to save model preference: $e");
-    }
-  }
-
-  void configureForStandardChat({
-    required ModelEntity model,
-    required bool isPremium,
-  }) {
-    selectModel(model, savePreference: false);
-  }
-
-  /// A complete state wipe out for when the user logs out.
   void resetForLogout() {
-    _isExitingChat = false;
-    _lastExitedModel = null;
     _selectedModel = null;
+    _pendingModelId = null;
     _isUserSubscribed = false;
-    _chatLimitManager = null;
     _displayName = null;
     _email = null;
+    _isStorageSufficient = true;
+    _isFluxMode = false;
+    _isExitingChat = false;
+    _lastExitedModel = null;
     _isLocalModelLoaded = false;
-    _isFluxMode = false;
-    ChatStorageService.isFluxMode = false;
-    _pendingModelId = null;
     notifyListeners();
   }
 
-  /// Resets session flags (Flux etc) but DOES NOT close the chat view.
-  /// Used when starting a new conversation to clear temporary states.
-  void resetSessionState() {
-    _lastExitedModel = _selectedModel;
-    _isExitingChat = true;
-
-    // Reset flags (Do not reset _isLocalModelLoaded here, it is tied to the physical cpp model instance)
-    _isFluxMode = false;
-    ChatStorageService.isFluxMode = false;
-
+  void setProfile({String? displayName, String? email}) {
+    _displayName = displayName;
+    _email = email;
     notifyListeners();
-
-    Future.delayed(const Duration(milliseconds: 400), () {
-      if (_isExitingChat) {
-        _isExitingChat = false;
-        _lastExitedModel = null;
-        notifyListeners();
-      }
-    });
-  }
-
-  void setDependencies(ModelLocalStateProvider localStateProvider) {
-    final wasResolved = _hasResolvedLocalModelState;
-    _localStateProvider = localStateProvider;
-    
-    // If the file system has just finished resolving, we MUST notify listeners
-    // so that the ChatScreen can fetch the correct modelPath and start caching.
-    if (!wasResolved && _hasResolvedLocalModelState) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        notifyListeners();
-      });
-    }
-    
-    unawaited(_reconcileSelectedModelAvailability());
-  }
-
-  bool get _hasResolvedLocalModelState {
-    final localState = _localStateProvider;
-    return localState != null &&
-        localState.isInitialized &&
-        localState.hasResolvedFilesDirectory;
-  }
-
-  bool _isOfflineModelAvailableById(String id) {
-    final localState = _localStateProvider;
-    if (localState == null || !_hasResolvedLocalModelState) {
-      // Local file state is still booting. Defer the final decision so a
-      // valid saved offline selection does not briefly get overwritten.
-      return true;
-    }
-
-    if (localState.downloadCompleted[id] == true) {
-      return true;
-    }
-
-    final path = localState.getFilePathById(id);
-    return localState.isModelOnDisk(path);
-  }
-
-  void removeDownloadedModel(String id) {
-    _localStateProvider?.removeDownloadedModel(id);
-  }
-
-  bool _canUseRestoredModel(ModelEntity entity) {
-    if (entity.id == 'cortex/auto' || entity.id == 'dynamic') return true;
-    if (entity.isServerSide) return true;
-
-    final variants = entity.variants;
-    if (variants != null && variants.isNotEmpty) {
-      return variants.keys.any(_isOfflineModelAvailableById);
-    }
-
-    return _isOfflineModelAvailableById(entity.id);
-  }
-
-  Future<ModelEntity> _resolveRestorableModelEntity(
-    String savedId,
-    String langCode,
-  ) async {
-    final entity =
-        _modelService.getPreciseModelData(savedId, langCode: langCode);
-
-    final variants = entity.variants;
-    if (entity.isServerSide || variants == null || variants.isEmpty) {
-      return entity;
-    }
-
-    final candidateIds = <String>[];
-    final lastUsedId = await Variants.getLastSelectedVariant(entity.id);
-    if (lastUsedId.isNotEmpty && variants.containsKey(lastUsedId)) {
-      candidateIds.add(lastUsedId);
-    }
-    candidateIds.addAll(variants.keys.where((id) => id != lastUsedId));
-
-    for (final candidateId in candidateIds) {
-      if (_isOfflineModelAvailableById(candidateId)) {
-        return _modelService.getPreciseModelData(
-          candidateId,
-          langCode: langCode,
-        );
-      }
-    }
-
-    return entity;
-  }
-
-  Future<void> _reconcileSelectedModelAvailability() async {
-    final model = _selectedModel;
-    if (model == null || model.isServerSide || !_hasResolvedLocalModelState) {
-      return;
-    }
-
-    final langCode = _currentLocale.languageCode;
-    final resolved = await _resolveRestorableModelEntity(model.id, langCode);
-
-    if (!_canUseRestoredModel(resolved)) {
-      debugPrint(
-          "[ChatSessionProvider] Saved offline model '${model.id}' is no longer available. Falling back to Dynamic Chat.");
-      startDynamicConversation(savePreference: true);
-      return;
-    }
-
-    if (resolved.id != model.id) {
-      selectModel(resolved, savePreference: true);
-    }
-  }
-
-  void setLocalModelLoaded(bool isLoaded) {
-    if (_isLocalModelLoaded != isLoaded) {
-      _isLocalModelLoaded = isLoaded;
-      notifyListeners();
-    }
-  }
-
-  void updateUserData(Map<String, dynamic> data) {
-    final int subscriptionLevel = _activeSubscriptionLevelFrom(data);
-    _isUserSubscribed = subscriptionLevel > 0;
-
-    _displayName =
-        data['displayName'] as String? ?? data['username'] as String?;
-    _email = data['email'] as String?;
-
-    final dynamic expiresValue = data['subscriptionExpiresAt'];
-    Timestamp? subscriptionExpiresAt;
-    if (expiresValue is Timestamp) {
-      subscriptionExpiresAt = expiresValue;
-    } else if (expiresValue is String) {
-      final parsedDate = DateTime.tryParse(expiresValue);
-      if (parsedDate != null) {
-        subscriptionExpiresAt = Timestamp.fromDate(parsedDate);
-      }
-    }
-
-    _chatLimitManager = ChatLimitManager(
-      cortexSubscription: subscriptionLevel,
-      subscriptionExpiresAt: subscriptionExpiresAt,
-    );
-
-    notifyListeners();
-  }
-
-  int _parseSubscriptionLevel(dynamic value) {
-    if (value is int) return value;
-    if (value is num) return value.toInt();
-    if (value is String) return int.tryParse(value) ?? 0;
-    return 0;
-  }
-
-  Timestamp? _parseSubscriptionTimestamp(dynamic value) {
-    if (value is Timestamp) return value;
-    if (value is DateTime) return Timestamp.fromDate(value);
-    if (value is String) {
-      final parsedDate = DateTime.tryParse(value);
-      if (parsedDate != null) {
-        return Timestamp.fromDate(parsedDate);
-      }
-    }
-    return null;
-  }
-
-  int _activeSubscriptionLevelFrom(Map<String, dynamic> data) {
-    final user = FirebaseAuth.instance.currentUser;
-    final isAnonymous =
-        (user?.isAnonymous ?? false) || data['accountType'] == 'anonymous';
-    if (isAnonymous) return 0;
-
-    final level = _parseSubscriptionLevel(data['hasCortexSubscription']);
-    if (level <= 0) return 0;
-
-    final expiry = _parseSubscriptionTimestamp(data['subscriptionExpiresAt']);
-    if (expiry == null) return level >= 4 && level <= 6 ? level : 0;
-    return expiry.toDate().isAfter(DateTime.now()) ? level : 0;
-  }
-
-  void setStorageSufficient(bool isSufficient) {
-    if (_isStorageSufficient != isSufficient) {
-      _isStorageSufficient = isSufficient;
-      notifyListeners();
-    }
   }
 }

--- a/lib/chat/providers/session.dart
+++ b/lib/chat/providers/session.dart
@@ -164,49 +164,19 @@ class ChatSessionProvider with ChangeNotifier {
   }
 
   bool _checkModality(String modality) {
-    final selected = _selectedModel;
-    if (selected == null) return false;
-    if (selected.modalities[modality] == true) return true;
+    if (_selectedModel == null) return false;
+    if (_selectedModel!.modalities[modality] == true) return true;
 
-    // A selected catalog entry can represent an entire series. The send layer
-    // resolves that series to a concrete variant for each request, so the UI
-    // capability check must use the same aggregate view. Previously this only
-    // inspected the parent map, causing the attachment UI and actual routing
-    // logic to disagree about whether a Claude/Llama/etc. series supported
-    // images, audio or video.
-    final variants = selected.variants;
-    if (variants != null && variants.isNotEmpty) {
-      for (final rawVariant in variants.values) {
-        if (rawVariant is! Map) continue;
-        final variant = Map<String, dynamic>.from(rawVariant);
-        final modalities = variant['modalities'];
-        if (modalities is Map && modalities[modality] == true) {
-          return true;
-        }
-      }
-    }
-
-    final isCharacter = selected.category == 'roleplay' ||
-        selected.category == 'self';
+    final isCharacter = _selectedModel!.category == 'roleplay' ||
+        _selectedModel!.category == 'self';
     if (isCharacter &&
-        selected.baseModelId != null &&
-        selected.baseModelId!.isNotEmpty) {
+        _selectedModel!.baseModelId != null &&
+        _selectedModel!.baseModelId!.isNotEmpty) {
       try {
         final baseModel = _modelService.getPreciseModelData(
-            selected.baseModelId!,
+            _selectedModel!.baseModelId!,
             langCode: _currentLocale.languageCode);
-        if (baseModel.modalities[modality] == true) return true;
-        final baseVariants = baseModel.variants;
-        if (baseVariants != null) {
-          for (final rawVariant in baseVariants.values) {
-            if (rawVariant is! Map) continue;
-            final variantModalities = rawVariant['modalities'];
-            if (variantModalities is Map &&
-                variantModalities[modality] == true) {
-              return true;
-            }
-          }
-        }
+        return baseModel.modalities[modality] == true;
       } catch (_) {}
     }
     return false;
@@ -292,247 +262,527 @@ class ChatSessionProvider with ChangeNotifier {
 
   ChatSessionProvider({
     required ModelService modelService,
-    ModelLocalStateProvider? localStateProvider,
-  })  : _modelService = modelService,
-        _localStateProvider = localStateProvider {
-    _listenToAuth();
-  }
-
-  void _listenToAuth() {
+    String initialModelId = 'cortex/auto',
+    String initialModelTitle = '', // [NEW] Cached title
+    Locale initialLocale = const Locale('en'),
+  }) : _modelService = modelService {
     try {
       _authSub = FirebaseAuth.instance.authStateChanges().listen((User? user) {
         if (user == null) {
           resetForLogout();
         }
       });
-    } catch (_) {
-      // Ignore during tests
+    } catch (e) {/* Ignore in tests */}
+
+    // Optimistic Initialization
+    _currentLocale = initialLocale;
+
+    // We try to load the model immediately.
+    // NOTE: ModelService might not have full catalog yet, but basic logic might work
+    // or we can fall back gracefully without setting it to null (which implies dynamic).
+
+    // If we can't find it immediately, we store it to resolve later?
+    // Actually, initializeDefaultSession() was doing async prefs read.
+    // Now we have the ID.
+
+    // Listen to ModelService updates to resolve pending model when catalog loads
+    _modelService.addListener(_onModelServiceUpdate);
+
+    // IMMEDIATE CHECK: In case it's already loaded or loading finished before listener attach
+    debugPrint(
+        "[ChatSessionProvider] Constructor: Attaching listener. Initial isLoading: ${_modelService.isLoading}");
+    if (!_modelService.isLoading) {
+      _onModelServiceUpdate();
+    }
+
+    // CRITICAL FIX: Check if cache is empty FIRST.
+    // If we call getPreciseModelData while cache is empty, ModelService returns a generic "Unknown Model" entity
+    // instead of throwing. This bypasses our catch block where we would use the cached title.
+    // So we must manually check cache state.
+    final bool isCacheEmpty = _modelService.getCachedModelsSync().isEmpty;
+
+    if (isCacheEmpty) {
+      debugPrint(
+          "[ChatSessionProvider] Cache is empty. Using cached title: '$initialModelTitle' for ID: $initialModelId");
+      _initializeWithStub(
+          initialModelId, ModelDataUtils.formatModelName(initialModelTitle));
+    } else {
+      final langCode = initialLocale.languageCode;
+      if (_modelService.hasModelInCache(initialModelId)) {
+        try {
+          final entity = _modelService.getPreciseModelData(initialModelId,
+              langCode: langCode);
+          selectModel(entity, savePreference: false);
+        } catch (e) {
+          // Fallback to stub if exact lookup fails even with cache present
+          _initializeWithStub(initialModelId,
+              ModelDataUtils.formatModelName(initialModelTitle));
+        }
+      } else {
+        // The saved model was removed from catalog. Default to dynamic chat.
+        startDynamicConversation(savePreference: true);
+      }
+    }
+  }
+
+  void _initializeWithStub(String modelId, String title) {
+    if (modelId == 'cortex/auto' || modelId == 'dynamic') {
+      startDynamicConversation(savePreference: false);
+    } else {
+      debugPrint(
+          "[ChatSessionProvider] Initialization fallback. Storing pending ID: $modelId");
+
+      // [FIX] Ensure title is never empty for the stub
+      String effectiveTitle = title;
+      if (effectiveTitle.isEmpty) {
+        if (modelId == 'cortex/auto') {
+          effectiveTitle = 'Cortex';
+        } else {
+          effectiveTitle = ModelDataUtils.formatModelName(modelId);
+        }
+      }
+
+      // Store for later resolution when catalog loads
+      _pendingModelId = modelId;
+
+      // Create stub with valid title if cached, otherwise empty
+      final stubEntity = ModelEntity(
+        id: modelId,
+        displayTitle: effectiveTitle,
+        producer: 'Vertex',
+        displaySummary: '',
+        displayDescription: '',
+        type: 'online',
+        source: 'openrouter',
+        category: 'general',
+        tier: 'free',
+        modalities: {'text': true},
+        outputs: {'text': true},
+        isFullyLocalized: true,
+        toolUse: false,
+      );
+      selectModel(stubEntity, savePreference: false);
+    }
+  }
+
+  void _onModelServiceUpdate() {
+    // Debug log to trace service updates
+    // debugPrint("[ChatSessionProvider] _onModelServiceUpdate. isLoading: ${_modelService.isLoading}, pendingId: $_pendingModelId");
+
+    // If models are loaded and we have a pending ID, try to resolve it
+    if (!_modelService.isLoading && _pendingModelId != null) {
+      unawaited(refreshModelAfterCatalogLoad());
     }
   }
 
   @override
   void dispose() {
+    _modelService.removeListener(_onModelServiceUpdate);
     _authSub?.cancel();
     super.dispose();
   }
 
-  // ===========================================================================
-  // SECTION 4: STATE MUTATION & MODEL SELECTION
-  // ===========================================================================
-
-  Future<void> initialize() async {
-    final prefs = await _sharedPrefs;
-    final savedModelId = prefs.getString(_prefDefaultModelKey);
-    if (savedModelId != null && savedModelId.isNotEmpty) {
-      _pendingModelId = savedModelId;
-    }
-  }
-
-  void updateDependencies({ModelLocalStateProvider? localStateProvider}) {
-    if (localStateProvider != null) {
-      _localStateProvider = localStateProvider;
-    }
-  }
-
-  /// Selects a model and persists the user's preferred model ID.
-  void selectModel(ModelEntity model) {
-    _selectedModel = model;
-    _pendingModelId = null;
-    _savePreferredModelId(model.id);
-    _updateLocalModelLoadedState();
-    notifyListeners();
-  }
-
-  /// Updates only the active variant ID while preserving the current series.
-  /// This is used by selectors where the series is already active but a concrete
-  /// backend variant is chosen.
-  void updateActiveModelVariant(String modelId) {
-    try {
-      final langCode = _currentLocale.languageCode;
-      final precise =
-          _modelService.getPreciseModelData(modelId, langCode: langCode);
-      _selectedModel = precise;
-    } catch (_) {
-      if (_selectedModel != null) {
-        _selectedModel = _selectedModel!.copyWith(id: modelId);
-      }
-    }
-    _pendingModelId = null;
-    _savePreferredModelId(modelId);
-    _updateLocalModelLoadedState();
-    notifyListeners();
-  }
-
-  void clearModelSelection() {
-    _selectedModel = null;
-    _pendingModelId = null;
-    _savePreferredModelId('cortex/auto');
-    _updateLocalModelLoadedState();
-    notifyListeners();
-  }
-
-  Future<void> _savePreferredModelId(String id) async {
-    try {
-      final prefs = await _sharedPrefs;
-      await prefs.setString(_prefDefaultModelKey, id);
-    } catch (_) {}
-  }
-
-  /// Re-resolves the currently selected model after the catalog is refreshed.
-  /// Important when Synapse metadata (modalities/variants/titles) changes.
-  void refreshSelectedModelFromCatalog() {
-    final currentId = _selectedModel?.id ?? _pendingModelId;
-    if (currentId == null || currentId.isEmpty || currentId == 'cortex/auto') {
-      return;
-    }
-    try {
-      _selectedModel = _modelService.getPreciseModelData(currentId,
-          langCode: _currentLocale.languageCode);
-      _pendingModelId = null;
-      _updateLocalModelLoadedState();
-      notifyListeners();
-    } catch (_) {}
-  }
-
+  /// Called when model catalog finishes loading to resolve pending model
   Future<void> refreshModelAfterCatalogLoad() async {
-    final id = _pendingModelId ?? _selectedModel?.id;
-    if (id == null || id.isEmpty || id == 'cortex/auto') return;
+    if (_pendingModelId == null) return;
+
+    final pendingId = _pendingModelId!;
+    debugPrint(
+        "[ChatSessionProvider] refreshModelAfterCatalogLoad: Attempting to resolve pending ID: $pendingId");
+
+    final langCode = _currentLocale.languageCode;
     try {
-      _selectedModel = _modelService.getPreciseModelData(id,
-          langCode: _currentLocale.languageCode);
-      _pendingModelId = null;
-      _updateLocalModelLoadedState();
-      notifyListeners();
-    } catch (_) {}
-  }
-
-  Future<void> setUserSubscribed(bool value) async {
-    if (_isUserSubscribed == value) return;
-    _isUserSubscribed = value;
-    notifyListeners();
-  }
-
-  Future<void> updateLocale(Locale locale) async {
-    if (_currentLocale == locale) return;
-    _currentLocale = locale;
-    // Re-resolve selected model so localized title/description stays correct.
-    refreshSelectedModelFromCatalog();
-    notifyListeners();
-  }
-
-  // ===========================================================================
-  // SECTION 5: LOCAL MODEL STATE
-  // ===========================================================================
-
-  void _updateLocalModelLoadedState() {
-    final selected = _selectedModel;
-    final local = _localStateProvider;
-    if (selected == null || selected.isServerSide) {
-      _isLocalModelLoaded = false;
-      return;
-    }
-
-    if (local == null ||
-        !local.isInitialized ||
-        !local.hasResolvedFilesDirectory) {
-      _isLocalModelLoaded = false;
-      return;
-    }
-
-    // For a series entry, consider it loaded if any local variant is on disk.
-    if (selected.variants != null && selected.variants!.isNotEmpty) {
-      _isLocalModelLoaded = selected.variants!.keys.any((variantId) {
-        final path = local.getFilePathById(variantId);
-        return local.isModelOnDisk(path);
-      });
-      return;
-    }
-
-    final path = local.getFilePathById(selected.id);
-    _isLocalModelLoaded = local.isModelOnDisk(path);
-  }
-
-  // ===========================================================================
-  // SECTION 6: CHAT SESSION HYDRATION / STORAGE
-  // ===========================================================================
-
-  Future<void> hydrateFromConversationModel(String? modelId) async {
-    if (modelId == null || modelId.isEmpty || modelId == 'cortex/auto') {
-      clearModelSelection();
-      return;
-    }
-    try {
-      final precise = _modelService.getPreciseModelData(modelId,
-          langCode: _currentLocale.languageCode);
-      _selectedModel = precise;
-      _pendingModelId = null;
-    } catch (_) {
-      _pendingModelId = modelId;
-    }
-    _updateLocalModelLoadedState();
-    notifyListeners();
-  }
-
-  void restoreSelectionWithoutPersistence(String? modelId) {
-    if (modelId == null || modelId.isEmpty || modelId == 'cortex/auto') {
-      _selectedModel = null;
-      _pendingModelId = null;
-    } else {
-      try {
-        _selectedModel = _modelService.getPreciseModelData(modelId,
-            langCode: _currentLocale.languageCode);
-        _pendingModelId = null;
-      } catch (_) {
-        _pendingModelId = modelId;
+      // Check if service actually has data now
+      if (_modelService.getCachedModelsSync().isEmpty) {
+        debugPrint(
+            "[ChatSessionProvider] refreshModelAfterCatalogLoad: Service cache still empty. Aborting.");
+        return;
       }
+
+      if (!_modelService.hasModelInCache(pendingId)) {
+        debugPrint(
+            "[ChatSessionProvider] Pending model '$pendingId' no longer exists. Falling back to dynamic.");
+        _pendingModelId = null;
+        startDynamicConversation(savePreference: true);
+        return;
+      }
+
+      final entity = await _resolveRestorableModelEntity(pendingId, langCode);
+
+      // Clear pending ID first so selectModel doesn't get confused or we don't retry unnecessarily
+      _pendingModelId = null;
+
+      if (!_canUseRestoredModel(entity)) {
+        debugPrint(
+            "[ChatSessionProvider] Pending model '$pendingId' is unavailable on this device. Falling back to dynamic.");
+        startDynamicConversation(savePreference: true);
+        return;
+      }
+
+      selectModel(entity, savePreference: false);
+      debugPrint(
+          "[ChatSessionProvider] Successfully resolved pending model: ${entity.displayTitle}");
+    } catch (e) {
+      debugPrint(
+          "[ChatSessionProvider] Failed to resolve pending model: $pendingId. Error: $e");
+      _pendingModelId = null;
+      startDynamicConversation(savePreference: true);
     }
-    _updateLocalModelLoadedState();
-    notifyListeners();
   }
 
   // ===========================================================================
-  // SECTION 7: FLAGS / RESET
+  // SECTION 4: STATE MUTATION METHODS (ACTIONS)
   // ===========================================================================
 
-  void setStorageSufficient(bool value) {
-    if (_isStorageSufficient == value) return;
-    _isStorageSufficient = value;
-    notifyListeners();
+  void setLocale(Locale locale) {
+    _currentLocale = locale;
   }
 
   void setFluxMode(bool value) {
-    if (_isFluxMode == value) return;
     _isFluxMode = value;
     notifyListeners();
   }
 
-  void setExitingChat(bool value) {
-    _isExitingChat = value;
-    if (value) {
-      _lastExitedModel = _selectedModel;
-    } else {
-      _lastExitedModel = null;
+  /// Selects a specific model entity for the session.
+  /// [savePreference]: If true, remembers this model as the default for future new chats.
+  void selectModel(ModelEntity entity, {bool savePreference = true}) {
+    final bool isSameModel = _selectedModel?.id == entity.id;
+    _isExitingChat = false;
+    _selectedModel = entity;
+
+    if (!entity.isServerSide && !isSameModel) {
+      _isLocalModelLoaded = false;
     }
+
+    final bool shouldSave = savePreference &&
+        entity.category != 'roleplay' &&
+        entity.category != 'self';
+
+    if (shouldSave) {
+      _savePreference(entity.id, entity.displayTitle);
+    }
+
     notifyListeners();
   }
 
-  void resetForLogout() {
+  /// Initializes the session based on the user's last selected preference.
+  /// This is called when the app starts or "New Chat" is clicked.
+  Future<void> initializeDefaultSession() async {
+    final prefs = await _sharedPrefs;
+    String savedId = prefs.getString(_prefDefaultModelKey) ?? 'cortex/auto';
+    final langCode = _currentLocale.languageCode;
+    try {
+      final bool isCacheEmpty = _modelService.getCachedModelsSync().isEmpty;
+
+      // If cache is empty, we must wait for catalog to load before making a final decision.
+      if (isCacheEmpty) {
+        String savedTitle = 'Cortex';
+        _initializeWithStub(savedId, savedTitle);
+        return;
+      }
+
+      // Check internet explicitly for offline fallback
+      final hasInternet = await InternetConnection().hasInternetAccess;
+      if (!hasInternet) {
+        // Find if we have any downloaded offline models
+        final allCachedModels = _modelService.getCachedModelsSync();
+        final offlineModels = allCachedModels.where((m) => m.type == 'offline');
+        final downloadedOfflineModels = offlineModels.where((m) {
+          final provider = _localStateProvider;
+          if (provider == null) return false;
+          final path = provider.getFilePathById(m.id);
+          return provider.isModelOnDisk(path);
+        }).toList();
+
+        if (downloadedOfflineModels.isNotEmpty) {
+          // If the user's saved model is NOT one of the downloaded offline models, override it
+          final isSavedModelDownloadedOffline =
+              downloadedOfflineModels.any((m) => m.id == savedId);
+          if (!isSavedModelDownloadedOffline) {
+            savedId = downloadedOfflineModels.first.id;
+          }
+        }
+      }
+
+      if (!_modelService.hasModelInCache(savedId)) {
+        startDynamicConversation(savePreference: true);
+        return;
+      }
+
+      final entity = await _resolveRestorableModelEntity(savedId, langCode);
+      if (!_canUseRestoredModel(entity)) {
+        startDynamicConversation(savePreference: true);
+        return;
+      }
+      selectModel(entity, savePreference: false);
+    } catch (e) {
+      startDynamicConversation(savePreference: true);
+    }
+  }
+
+  /// Sets up the session for Dynamic Chat (Implicitly cortex/auto).
+  /// This effectively just sets selectedModel to null.
+  void startDynamicConversation({bool savePreference = true}) {
+    _isExitingChat = false;
     _selectedModel = null;
-    _pendingModelId = null;
-    _isUserSubscribed = false;
-    _displayName = null;
-    _email = null;
-    _isStorageSufficient = true;
-    _isFluxMode = false;
+    _isLocalModelLoaded = false;
+
+    if (savePreference) {
+      _savePreference('cortex/auto', '');
+    }
+
+    notifyListeners();
+  }
+
+  /// Updates the variant of the currently active model.
+  void updateActiveModelVariant(String newModelId,
+      {bool savePreference = true}) {
+    final langCode = _currentLocale.languageCode;
+    _selectedModel =
+        _modelService.getPreciseModelData(newModelId, langCode: langCode);
+
+    final bool shouldSave = savePreference &&
+        _selectedModel?.category != 'roleplay' &&
+        _selectedModel?.category != 'self';
+
+    if (shouldSave) {
+      _savePreference(newModelId, _selectedModel!.displayTitle);
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> _savePreference(String id, String title) async {
+    try {
+      final prefs = await _sharedPrefs;
+      await prefs.setString(_prefDefaultModelKey, id);
+      await prefs.setString('${_prefDefaultModelKey}_title', title);
+    } catch (e) {
+      debugPrint("Failed to save model preference: $e");
+    }
+  }
+
+  void configureForStandardChat({
+    required ModelEntity model,
+    required bool isPremium,
+  }) {
+    selectModel(model, savePreference: false);
+  }
+
+  /// A complete state wipe out for when the user logs out.
+  void resetForLogout() {
     _isExitingChat = false;
     _lastExitedModel = null;
+    _selectedModel = null;
+    _isUserSubscribed = false;
+    _chatLimitManager = null;
+    _displayName = null;
+    _email = null;
     _isLocalModelLoaded = false;
+    _isFluxMode = false;
+    ChatStorageService.isFluxMode = false;
+    _pendingModelId = null;
     notifyListeners();
   }
 
-  void setProfile({String? displayName, String? email}) {
-    _displayName = displayName;
-    _email = email;
+  /// Resets session flags (Flux etc) but DOES NOT close the chat view.
+  /// Used when starting a new conversation to clear temporary states.
+  void resetSessionState() {
+    _lastExitedModel = _selectedModel;
+    _isExitingChat = true;
+
+    // Reset flags (Do not reset _isLocalModelLoaded here, it is tied to the physical cpp model instance)
+    _isFluxMode = false;
+    ChatStorageService.isFluxMode = false;
+
     notifyListeners();
+
+    Future.delayed(const Duration(milliseconds: 400), () {
+      if (_isExitingChat) {
+        _isExitingChat = false;
+        _lastExitedModel = null;
+        notifyListeners();
+      }
+    });
+  }
+
+  void setDependencies(ModelLocalStateProvider localStateProvider) {
+    final wasResolved = _hasResolvedLocalModelState;
+    _localStateProvider = localStateProvider;
+    
+    // If the file system has just finished resolving, we MUST notify listeners
+    // so that the ChatScreen can fetch the correct modelPath and start caching.
+    if (!wasResolved && _hasResolvedLocalModelState) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        notifyListeners();
+      });
+    }
+    
+    unawaited(_reconcileSelectedModelAvailability());
+  }
+
+  bool get _hasResolvedLocalModelState {
+    final localState = _localStateProvider;
+    return localState != null &&
+        localState.isInitialized &&
+        localState.hasResolvedFilesDirectory;
+  }
+
+  bool _isOfflineModelAvailableById(String id) {
+    final localState = _localStateProvider;
+    if (localState == null || !_hasResolvedLocalModelState) {
+      // Local file state is still booting. Defer the final decision so a
+      // valid saved offline selection does not briefly get overwritten.
+      return true;
+    }
+
+    if (localState.downloadCompleted[id] == true) {
+      return true;
+    }
+
+    final path = localState.getFilePathById(id);
+    return localState.isModelOnDisk(path);
+  }
+
+  void removeDownloadedModel(String id) {
+    _localStateProvider?.removeDownloadedModel(id);
+  }
+
+  bool _canUseRestoredModel(ModelEntity entity) {
+    if (entity.id == 'cortex/auto' || entity.id == 'dynamic') return true;
+    if (entity.isServerSide) return true;
+
+    final variants = entity.variants;
+    if (variants != null && variants.isNotEmpty) {
+      return variants.keys.any(_isOfflineModelAvailableById);
+    }
+
+    return _isOfflineModelAvailableById(entity.id);
+  }
+
+  Future<ModelEntity> _resolveRestorableModelEntity(
+    String savedId,
+    String langCode,
+  ) async {
+    final entity =
+        _modelService.getPreciseModelData(savedId, langCode: langCode);
+
+    final variants = entity.variants;
+    if (entity.isServerSide || variants == null || variants.isEmpty) {
+      return entity;
+    }
+
+    final candidateIds = <String>[];
+    final lastUsedId = await Variants.getLastSelectedVariant(entity.id);
+    if (lastUsedId.isNotEmpty && variants.containsKey(lastUsedId)) {
+      candidateIds.add(lastUsedId);
+    }
+    candidateIds.addAll(variants.keys.where((id) => id != lastUsedId));
+
+    for (final candidateId in candidateIds) {
+      if (_isOfflineModelAvailableById(candidateId)) {
+        return _modelService.getPreciseModelData(
+          candidateId,
+          langCode: langCode,
+        );
+      }
+    }
+
+    return entity;
+  }
+
+  Future<void> _reconcileSelectedModelAvailability() async {
+    final model = _selectedModel;
+    if (model == null || model.isServerSide || !_hasResolvedLocalModelState) {
+      return;
+    }
+
+    final langCode = _currentLocale.languageCode;
+    final resolved = await _resolveRestorableModelEntity(model.id, langCode);
+
+    if (!_canUseRestoredModel(resolved)) {
+      debugPrint(
+          "[ChatSessionProvider] Saved offline model '${model.id}' is no longer available. Falling back to Dynamic Chat.");
+      startDynamicConversation(savePreference: true);
+      return;
+    }
+
+    if (resolved.id != model.id) {
+      selectModel(resolved, savePreference: true);
+    }
+  }
+
+  void setLocalModelLoaded(bool isLoaded) {
+    if (_isLocalModelLoaded != isLoaded) {
+      _isLocalModelLoaded = isLoaded;
+      notifyListeners();
+    }
+  }
+
+  void updateUserData(Map<String, dynamic> data) {
+    final int subscriptionLevel = _activeSubscriptionLevelFrom(data);
+    _isUserSubscribed = subscriptionLevel > 0;
+
+    _displayName =
+        data['displayName'] as String? ?? data['username'] as String?;
+    _email = data['email'] as String?;
+
+    final dynamic expiresValue = data['subscriptionExpiresAt'];
+    Timestamp? subscriptionExpiresAt;
+    if (expiresValue is Timestamp) {
+      subscriptionExpiresAt = expiresValue;
+    } else if (expiresValue is String) {
+      final parsedDate = DateTime.tryParse(expiresValue);
+      if (parsedDate != null) {
+        subscriptionExpiresAt = Timestamp.fromDate(parsedDate);
+      }
+    }
+
+    _chatLimitManager = ChatLimitManager(
+      cortexSubscription: subscriptionLevel,
+      subscriptionExpiresAt: subscriptionExpiresAt,
+    );
+
+    notifyListeners();
+  }
+
+  int _parseSubscriptionLevel(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value) ?? 0;
+    return 0;
+  }
+
+  Timestamp? _parseSubscriptionTimestamp(dynamic value) {
+    if (value is Timestamp) return value;
+    if (value is DateTime) return Timestamp.fromDate(value);
+    if (value is String) {
+      final parsedDate = DateTime.tryParse(value);
+      if (parsedDate != null) {
+        return Timestamp.fromDate(parsedDate);
+      }
+    }
+    return null;
+  }
+
+  int _activeSubscriptionLevelFrom(Map<String, dynamic> data) {
+    final user = FirebaseAuth.instance.currentUser;
+    final isAnonymous =
+        (user?.isAnonymous ?? false) || data['accountType'] == 'anonymous';
+    if (isAnonymous) return 0;
+
+    final level = _parseSubscriptionLevel(data['hasCortexSubscription']);
+    if (level <= 0) return 0;
+
+    final expiry = _parseSubscriptionTimestamp(data['subscriptionExpiresAt']);
+    if (expiry == null) return level >= 4 && level <= 6 ? level : 0;
+    return expiry.toDate().isAfter(DateTime.now()) ? level : 0;
+  }
+
+  void setStorageSufficient(bool isSufficient) {
+    if (_isStorageSufficient != isSufficient) {
+      _isStorageSufficient = isSufficient;
+      notifyListeners();
+    }
   }
 }

--- a/lib/chat/screen/widgets/bottom/input/service.dart
+++ b/lib/chat/screen/widgets/bottom/input/service.dart
@@ -67,12 +67,14 @@ class InputService {
     try {
       if (source == ImageSource.gallery) {
         List<XFile> pickedFiles = [];
+        bool pickedImages = false;
         if (supportImage) {
           pickedFiles = await _imagePicker.pickMultiImage(
             imageQuality: 80,
             maxWidth: 1920,
             maxHeight: 1920,
           );
+          pickedImages = true;
         } else if (supportVideo) {
           final XFile? file = await _imagePicker.pickVideo(source: source);
           if (file != null) pickedFiles.add(file);
@@ -84,16 +86,19 @@ class InputService {
           if (!_canAddMoreAttachments(inputProvider)) break;
 
           final File file = File(pickedFile.path);
-          final String pathLower = file.path.toLowerCase();
-          final bool isImage = ['.png', '.jpg', '.jpeg', '.webp', '.gif']
-              .any((ext) => pathLower.endsWith(ext));
-
+          // ImagePicker already tells us which picker was used. Do not infer
+          // this again from a temporary cache filename, which may have a
+          // generic or missing extension on some Android/iOS devices.
           await _validateAndAddAttachment(inputProvider, file,
-              isImage: isImage);
+              isImage: pickedImages);
+        }
+
+        if (pickedImages) {
+          _promoteSelectedSeriesForImage(context);
         }
       } else {
         XFile? pickedFile;
-        // For camera, usually we separate pickImage and pickVideo, but here we just keep pickImage for now unless video is specifically supported (camera video recording).
+        bool pickedImage = false;
         if (supportImage) {
           pickedFile = await _imagePicker.pickImage(
             source: source,
@@ -101,6 +106,7 @@ class InputService {
             maxWidth: 1920,
             maxHeight: 1920,
           );
+          pickedImage = true;
         } else if (supportVideo) {
           pickedFile = await _imagePicker.pickVideo(source: source);
         }
@@ -108,11 +114,11 @@ class InputService {
         if (pickedFile == null) return;
 
         final File file = File(pickedFile.path);
-        final String pathLower = file.path.toLowerCase();
-        final bool isImage = ['.png', '.jpg', '.jpeg', '.webp', '.gif']
-            .any((ext) => pathLower.endsWith(ext));
-
-        await _validateAndAddAttachment(inputProvider, file, isImage: isImage);
+        await _validateAndAddAttachment(inputProvider, file,
+            isImage: pickedImage);
+        if (pickedImage) {
+          _promoteSelectedSeriesForImage(context);
+        }
       }
 
       onSelectionComplete();
@@ -142,17 +148,14 @@ class InputService {
       final FilePickerResult? result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
         allowedExtensions: dynamicExtensions,
-        allowMultiple: true, // Allow selecting multiple files at once
+        allowMultiple: true,
       );
 
       if (result == null || result.files.isEmpty) return;
 
       // 3. Process each selected file
-      // We loop through them to validate limits individually.
       for (final platformFile in result.files) {
         if (platformFile.path == null) continue;
-
-        // Stop if user tries to add more than the limit in a batch
         if (!_canAddMoreAttachments(inputProvider)) break;
 
         final File file = File(platformFile.path!);
@@ -168,10 +171,8 @@ class InputService {
 
   // --- Helper: Validation & State Update ---
 
-  /// Checks if the user has reached the maximum number of attachments (4).
   bool _canAddMoreAttachments(InputProvider inputProvider) {
     if (inputProvider.attachments.length >= _maxAttachmentCount) {
-      // Optional: Show a toast/snackbar here telling the user "Max 4 files".
       debugPrint("Attachment limit reached ($_maxAttachmentCount).");
       return false;
     }
@@ -182,26 +183,71 @@ class InputService {
   Future<void> _validateAndAddAttachment(InputProvider inputProvider, File file,
       {required bool isImage}) async {
     try {
-      // Async operation: Get file size
       final int sizeInBytes = await file.length();
 
-      // Security Check:
-      // Even if a user renames 'game.exe' (500MB) to 'game.txt',
-      // this check prevents it from entering our system.
       if (sizeInBytes > _maxFileSizeInBytes) {
         debugPrint(
             "File rejected: Size (${sizeInBytes / 1024 / 1024} MB) exceeds limit.");
-        // Optional: Trigger a UI notification via a helper service
         return;
       }
 
-      // Add to provider
       debugPrint(
           "InputService: File validated. Adding to provider: ${file.path}");
       inputProvider.addAttachment(file, isImage: isImage);
     } catch (e) {
       debugPrint("Error validating file: $e");
     }
+  }
+
+  /// If a server-side series contains a dedicated vision variant, select that
+  /// concrete variant as soon as an image is attached. This keeps the visible
+  /// series choice while preventing SendService from ever silently falling
+  /// back to the first text-only variant for the image request.
+  void _promoteSelectedSeriesForImage(BuildContext context) {
+    final sessionProvider = context.read<ChatSessionProvider>();
+    if (sessionProvider.isDynamicChat) return;
+
+    final selected = sessionProvider.selectedModel;
+    final variants = selected?.variants;
+    if (selected == null ||
+        !selected.isServerSide ||
+        variants == null ||
+        variants.isEmpty) {
+      return;
+    }
+
+    String? fallbackVisionId;
+    String? preferredVisionId;
+
+    for (final entry in variants.entries) {
+      final raw = entry.value;
+      if (raw is! Map) continue;
+      final variant = Map<String, dynamic>.from(raw);
+      final modalities = variant['modalities'];
+      if (modalities is! Map || modalities['image'] != true) continue;
+
+      final id = variant['id']?.toString().trim() ?? entry.key.trim();
+      if (id.isEmpty || id.toLowerCase().contains('guard')) continue;
+
+      fallbackVisionId ??= id;
+      final tier = variant['tier']?.toString().toLowerCase() ?? 'free';
+      final needsPaidAccess = tier == 'premium' ||
+          tier == 'plus' ||
+          tier == 'pro' ||
+          tier == 'ultra';
+      if (!needsPaidAccess || sessionProvider.isUserSubscribed) {
+        preferredVisionId = id;
+        break;
+      }
+    }
+
+    final targetId = preferredVisionId ??
+        (sessionProvider.isUserSubscribed ? fallbackVisionId : null);
+    if (targetId == null || targetId == sessionProvider.modelId) return;
+
+    debugPrint(
+        "[InputService] Image attached. Promoting series '${selected.id}' to vision variant '$targetId'.");
+    sessionProvider.updateActiveModelVariant(targetId);
   }
 
   // --- Model Selection Logic (Existing) ---
@@ -256,6 +302,14 @@ class InputService {
       } else {
         sessionProvider.updateActiveModelVariant(newModelId);
       }
+
+      // If an image was attached before switching models, re-resolve the newly
+      // selected series to its vision variant immediately.
+      final inputProvider = context.read<InputProvider>();
+      if (inputProvider.attachments
+          .any((attachment) => attachment.type == AttachmentType.image)) {
+        _promoteSelectedSeriesForImage(context);
+      }
     } catch (e) {
       debugPrint("Error switching model: $e");
       sessionProvider.updateActiveModelVariant(newModelId);
@@ -269,21 +323,19 @@ class InputService {
     required bool isServerSide,
     required bool isDynamicChat,
     required bool isPremium,
-    required int attachmentCount, // New Parameter: Number of files
-    required bool isSearchEnabled, // Included web search cost
-    bool isRagEnabled = false, // Included document-chat (RAG) cost
+    required int attachmentCount,
+    required bool isSearchEnabled,
+    bool isRagEnabled = false,
   }) {
     if (!isServerSide) return 0;
 
-    // Define Costs
     const int attachmentCostPerUnit = 30;
     const int searchCost = 5;
     const int ragCost = 5;
 
-    // Determine Base Cost
-    int baseCost = 5; // Standard
+    int baseCost = 5;
     if (isDynamicChat || isPremium) {
-      baseCost = 20; // Premium / Auto
+      baseCost = 20;
     }
 
     if (isSearchEnabled) {
@@ -294,9 +346,7 @@ class InputService {
       baseCost += ragCost;
     }
 
-    // Formula: Base + (N * 30)
     final int totalAttachmentCost = attachmentCount * attachmentCostPerUnit;
-
     return baseCost + totalAttachmentCost;
   }
 
@@ -316,7 +366,6 @@ class InputService {
     required int? availablePredits,
     required int? availableDredits,
   }) {
-    // 1. Basic Blockers
     if (modelMissing || isSending || !isStorageSufficient || isLimitExceeded) {
       return false;
     }
@@ -325,30 +374,17 @@ class InputService {
       return false;
     }
 
+    final sessionProvider = context.read<ChatSessionProvider>();
     final isOfflineMode = !isDynamicChatMode && !isServerSideModel;
-    if (isOfflineMode &&
-        !context.read<ChatSessionProvider>().isLocalModelLoaded) {
+    if (isOfflineMode && !sessionProvider.isLocalModelLoaded) {
       return false;
     }
 
-    // 2. Credit gate
-    //
-    // Billing v2 retired the premium lane and the Dynamic Chat currency: every
-    // model bills its real cost against one balance, so both cases collapse
-    // into "can they afford to start a text request". canUsePremiumModel and
-    // canSendDynamicChat keep the pre-migration behaviour for accounts the
-    // lazy migration has not touched yet.
     final creditsManager = context.read<CreditsManager>();
-
-    // Past the debt floor nothing is sendable until the allowance renews, and
-    // that holds for every lane rather than the one the user happens to be in.
     if (!creditsManager.canSendAnything) {
       return false;
     }
 
-    // The lane-specific currencies below exist only outside the daily engine.
-    // Under it a model the user may not choose is rewritten to Dynamic Chat
-    // rather than refused, so it is not a reason to disable sending.
     if (!creditsManager.creditsV3Notifier.value) {
       if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
         if (!creditsManager.canUsePremiumModel) {
@@ -356,18 +392,25 @@ class InputService {
         }
       }
 
-      if (isDynamicChatMode) {
-        if (!creditsManager.canSendDynamicChat) {
-          return false;
-        }
+      if (isDynamicChatMode && !creditsManager.canSendDynamicChat) {
+        return false;
       }
     }
 
     final inputProvider = context.read<InputProvider>();
+    final bool hasImageAttachment = inputProvider.attachments
+        .any((attachment) => attachment.type == AttachmentType.image);
+
+    // Never allow an image to be silently sent through a model that cannot
+    // consume images. Dynamic Chat is exempt because SendService routes it to a
+    // vision-capable model for the request.
+    if (!isDynamicChatMode &&
+        hasImageAttachment &&
+        !sessionProvider.canHandleImage) {
+      return false;
+    }
 
     final int attachmentCount = inputProvider.attachments.length;
-
-    // 4. Overall Credit Check
     final needed = calculateRequiredCredits(
       isServerSide: isServerSideModel,
       isDynamicChat: isDynamicChatMode,
@@ -404,7 +447,6 @@ class InputService {
     required int? availablePredits,
     required int? availableDredits,
   }) {
-    // 1. Basic Blockers
     if (modelMissing || isSending || !isStorageSufficient || isLimitExceeded) {
       return false;
     }
@@ -413,30 +455,17 @@ class InputService {
       return false;
     }
 
+    final sessionProvider = context.read<ChatSessionProvider>();
     final isOfflineMode = !isDynamicChatMode && !isServerSideModel;
-    if (isOfflineMode &&
-        !context.read<ChatSessionProvider>().isLocalModelLoaded) {
+    if (isOfflineMode && !sessionProvider.isLocalModelLoaded) {
       return false;
     }
 
-    // 2. Credit gate
-    //
-    // Billing v2 retired the premium lane and the Dynamic Chat currency: every
-    // model bills its real cost against one balance, so both cases collapse
-    // into "can they afford to start a text request". canUsePremiumModel and
-    // canSendDynamicChat keep the pre-migration behaviour for accounts the
-    // lazy migration has not touched yet.
     final creditsManager = context.read<CreditsManager>();
-
-    // Past the debt floor nothing is sendable until the allowance renews, and
-    // that holds for every lane rather than the one the user happens to be in.
     if (!creditsManager.canSendAnything) {
       return false;
     }
 
-    // The lane-specific currencies below exist only outside the daily engine.
-    // Under it a model the user may not choose is rewritten to Dynamic Chat
-    // rather than refused, so it is not a reason to disable sending.
     if (!creditsManager.creditsV3Notifier.value) {
       if (!isDynamicChatMode && isPremiumModel && !isSubscribed) {
         if (!creditsManager.canUsePremiumModel) {
@@ -444,21 +473,25 @@ class InputService {
         }
       }
 
-      if (isDynamicChatMode) {
-        if (!creditsManager.canSendDynamicChat) {
-          return false;
-        }
+      if (isDynamicChatMode && !creditsManager.canSendDynamicChat) {
+        return false;
       }
     }
 
     final inputProvider = context.read<InputProvider>();
     final String currentText = controller.text.trim();
 
-    // UPDATED: Check list length instead of single photo
     final int attachmentCount = inputProvider.attachments.length;
     final bool hasAttachments = attachmentCount > 0;
+    final bool hasImageAttachment = inputProvider.attachments
+        .any((attachment) => attachment.type == AttachmentType.image);
 
-    // 4. Overall Credit Check
+    if (!isDynamicChatMode &&
+        hasImageAttachment &&
+        !sessionProvider.canHandleImage) {
+      return false;
+    }
+
     final needed = calculateRequiredCredits(
       isServerSide: isServerSideModel,
       isDynamicChat: isDynamicChatMode,
@@ -475,12 +508,10 @@ class InputService {
       return false;
     }
 
-    // 5. Content Validation
     if (inputProvider.isEditingMode) {
       return currentText.isNotEmpty || hasAttachments;
     }
 
-    // Standard Mode: Must have text OR attachments
     return currentText.isNotEmpty || hasAttachments;
   }
 }

--- a/lib/chat/services/context.dart
+++ b/lib/chat/services/context.dart
@@ -82,9 +82,39 @@ class ContextService {
 
     // Brief tone/style instruction
     if (!isCharacterModel) {
-      final toneDirective =
+      const toneDirective =
           "\n\nBe natural, conversational and direct. Avoid poetic or dramatic language unless asked.";
       systemRole = (systemRole ?? fallbackRole) + toneDirective;
+    }
+
+    // Keep model identity deterministic. Model IDs stored on old assistant
+    // messages are UI metadata and must never be used as conversational text.
+    // Dynamic Chat intentionally hides the provider selected for an individual
+    // request, so it identifies itself as Cortex rather than hallucinating a
+    // provider/model name.
+    if (!isCharacterModel) {
+      final isDynamicIdentity = _sessionProvider.isDynamicChat ||
+          targetModelId == 'cortex/auto' ||
+          targetModelId == 'dynamic';
+
+      String identityDirective;
+      if (isDynamicIdentity) {
+        identityDirective =
+            "\n\n[Runtime identity]\nYou are Cortex Dynamic Chat. The underlying provider may be selected automatically per request. If the user asks which model you are, identify yourself as Cortex Dynamic Chat and do not invent or claim a specific OpenAI, Anthropic, Meta, Google, or other provider model.";
+      } else {
+        final targetModel =
+            _modelService.getPreciseModelData(targetModelId, langCode: langCode);
+        final title = targetModel.displayTitle.trim();
+        final producer = targetModel.producer.trim();
+        final identity = producer.isNotEmpty &&
+                producer.toLowerCase() != 'unknown' &&
+                !title.toLowerCase().startsWith(producer.toLowerCase())
+            ? '$producer $title'
+            : title;
+        identityDirective =
+            "\n\n[Runtime identity]\nYou are currently running as ${identity.isEmpty ? targetModel.id : identity} (model id: ${targetModel.id}). If the user asks which model you are, use this runtime identity. Never claim to be a different model or provider based on training data, prior assistant messages, or guesses.";
+      }
+      systemRole = (systemRole ?? fallbackRole) + identityDirective;
     }
 
     // Thinking mode
@@ -143,6 +173,13 @@ class ContextService {
           modality: 'image',
         );
 
+    // Hard system prompt character budget. Apply the budget before adding the
+    // system message so the actual payload is bounded too.
+    const int systemBudget = 2500;
+    if (systemRole != null && systemRole.length > systemBudget) {
+      systemRole = systemRole.substring(0, systemBudget);
+    }
+
     // Add the system prompt to the context, if it exists.
     if (systemRole != null && systemRole.isNotEmpty) {
       contextMessages.add({"role": "system", "content": systemRole});
@@ -175,12 +212,6 @@ class ContextService {
         if (c is String) len += c.length + 1;
       }
       return len;
-    }
-
-    // Hard system prompt character budget
-    const int systemBudget = 2500;
-    if (systemRole != null && systemRole.length > systemBudget) {
-      systemRole = systemRole.substring(0, systemBudget);
     }
 
     final int originalLength = totalContentLength(contextMessages);
@@ -217,13 +248,13 @@ class ContextService {
     List<Map<String, dynamic>> textParts = [];
     List<Map<String, dynamic>> mediaParts = [];
 
-    // 1. Text Content
+    // 1. Text Content. `message.model` is UI/storage metadata, not dialogue.
+    // Prefixing it into assistant text causes cross-model identity contamination
+    // when the user switches from e.g. Cortex to Llama or Claude.
     if (message.text.isNotEmpty) {
       final String processedText = message.isUserMessage
           ? LocalPiiRedactionFilter.redact(message.text)
-          : (message.model != null && message.model!.isNotEmpty
-              ? "[Model: ${message.model}] ${message.text}"
-              : message.text);
+          : message.text;
       textParts.add({"type": "text", "text": processedText});
     }
 

--- a/lib/chat/services/context.dart
+++ b/lib/chat/services/context.dart
@@ -45,20 +45,17 @@ class ContextService {
   }) async {
     final List<Map<String, dynamic>> contextMessages = [];
 
-    // Read the system role from the session provider.
     String? systemRole = _sessionProvider.role;
     String? runtimeIdentityDirective;
 
     final String fallbackRole =
         localizations?.systemRoleFallback ?? "You are a helpful assistant.";
 
-    // Language instruction FIRST to prevent English-heavy blocks below from priming the model
     if (localizations != null) {
       systemRole = (systemRole ?? fallbackRole) +
           localizations.systemLanguageInstruction;
     }
 
-    // Inject current date and time for non-character models
     if (localizations != null && !isCharacterModel) {
       final now = DateTime.now();
       final formattedTime = DateFormat.yMMMd(langCode).add_Hm().format(now);
@@ -66,13 +63,11 @@ class ContextService {
           localizations.systemTimeInfo(formattedTime);
     }
 
-    // User memory - short, relevant facts only
     if (isServerSide && userMemory != null && userMemory.trim().isNotEmpty) {
       final memoryPrompt = "\n\n[User Memory]\n$userMemory";
       systemRole = (systemRole ?? fallbackRole) + memoryPrompt;
     }
 
-    // Custom instruction (Intelligence)
     if (customInstruction != null &&
         customInstruction.trim().isNotEmpty &&
         localizations != null) {
@@ -81,18 +76,15 @@ class ContextService {
       systemRole = (systemRole ?? fallbackRole) + instructionPrompt;
     }
 
-    // Brief tone/style instruction
     if (!isCharacterModel) {
       const toneDirective =
           "\n\nBe natural, conversational and direct. Avoid poetic or dramatic language unless asked.";
       systemRole = (systemRole ?? fallbackRole) + toneDirective;
     }
 
-    // Keep model identity deterministic. Model IDs stored on old assistant
-    // messages are UI metadata and must never be used as conversational text.
-    // Dynamic Chat intentionally hides the provider selected for an individual
-    // request, so it identifies itself as Cortex rather than hallucinating a
-    // provider/model name.
+    // Model IDs stored on assistant messages are presentation/storage metadata.
+    // Keep the model's runtime identity out of conversation history and define it
+    // once from the actual model selected for this request.
     if (!isCharacterModel) {
       final isDynamicIdentity = _sessionProvider.isDynamicChat ||
           targetModelId == 'cortex/auto' ||
@@ -116,15 +108,12 @@ class ContextService {
       }
     }
 
-    // Thinking mode
     if (enableThinkingMode && localizations != null) {
       final thinkingInstruction =
           "\n\n${localizations.thinkingModeInstruction}";
       systemRole = (systemRole ?? fallbackRole) + thinkingInstruction;
     }
 
-    // Read the message list from the conversation provider and filter for valid context.
-    // We specifically exclude messages that are not visible to the user (e.g., pre-input prompts).
     List<Message> history = _conversationProvider.messages
         .where((m) =>
             m.includeInContext && !m.isThinking && !m.isError && m.isVisible)
@@ -134,7 +123,6 @@ class ContextService {
 
     final bool isLowEnd = _isLowEndModel(targetModelId);
 
-    // Memory extraction: only after meaningful conversation (3+ user messages)
     if (isServerSide && !isCharacterModel && userMessageCount >= 3) {
       final extractionInstruction = localizations != null
           ? localizations.systemMemoryDirective
@@ -142,7 +130,6 @@ class ContextService {
       systemRole = (systemRole ?? fallbackRole) + extractionInstruction;
     }
 
-    // Retrieve related context from past conversations
     String? lastUserText;
     if (history.isNotEmpty) {
       final lastUserMsg =
@@ -172,12 +159,11 @@ class ContextService {
           modality: 'image',
         );
 
-    // Hard system prompt character budget. Reserve room for the runtime identity
-    // so it cannot be truncated away by a long persona/memory prompt.
     const int systemBudget = 2500;
     if (runtimeIdentityDirective != null) {
       final reserved = runtimeIdentityDirective.length + 2;
-      final baseBudget = (systemBudget - reserved).clamp(0, systemBudget);
+      final int baseBudget =
+          systemBudget > reserved ? systemBudget - reserved : 0;
       final base = systemRole ?? fallbackRole;
       systemRole = base.length > baseBudget
           ? base.substring(0, baseBudget)
@@ -188,13 +174,10 @@ class ContextService {
       systemRole = systemRole.substring(0, systemBudget);
     }
 
-    // Add the system prompt to the context, if it exists.
     if (systemRole != null && systemRole.isNotEmpty) {
       contextMessages.add({"role": "system", "content": systemRole});
     }
 
-    // If we're regenerating a response, exclude the last user message
-    // because it will be added again by the SendService.
     if (!includeLastUser && history.isNotEmpty) {
       final int lastUserMessageIndex =
           history.lastIndexWhere((m) => m.isUserMessage);
@@ -203,7 +186,6 @@ class ContextService {
       }
     }
 
-    // Loop through the filtered history and format each message into the API's required JSON structure.
     for (final message in history) {
       contextMessages.addAll(await _formatMessagesToJson(
         message,
@@ -236,7 +218,6 @@ class ContextService {
       compressedPromptLength: compressedLength,
     );
 
-    // Safety check: Filter out empty messages.
     final result = compressedMessages.where((m) {
       final content = m['content'];
       if (content is String) return content.isNotEmpty;
@@ -244,11 +225,10 @@ class ContextService {
       return false;
     }).toList();
 
-    // OfflineService converts only user/assistant history turns into the native
-    // llama prompt and intentionally ignores ContextService's system entry.
-    // Repeat the small runtime identity as the final context instruction for
-    // offline models so a local Llama/Qwen/etc. cannot claim to be GPT/Claude
-    // merely because of its training data. This is not added for online calls.
+    // OfflineService intentionally converts only user/assistant history turns
+    // into the native llama prompt. Carry the runtime identity as the final
+    // offline context instruction so local models cannot self-identify from
+    // their training data instead of the model Cortex actually loaded.
     if (!isServerSide && runtimeIdentityDirective != null) {
       result.add({
         "role": "user",
@@ -259,9 +239,6 @@ class ContextService {
     return result;
   }
 
-  /// Helper function to convert a single `Message` object to the required
-  /// multimodal JSON format. If the assistant generated an image, we split it
-  /// into a separate synthetic user message so the vision API accepts it.
   Future<List<Map<String, dynamic>>> _formatMessagesToJson(Message message,
       {required bool includeImage,
       required bool includeAllMedia,
@@ -270,9 +247,8 @@ class ContextService {
     List<Map<String, dynamic>> textParts = [];
     List<Map<String, dynamic>> mediaParts = [];
 
-    // 1. Text Content. `message.model` is UI/storage metadata, not dialogue.
-    // Prefixing it into assistant text causes cross-model identity contamination
-    // when the user switches from e.g. Cortex to Llama or Claude.
+    // `message.model` is UI/storage metadata, not dialogue. Prefixing it into
+    // assistant content contaminates the next model after a model switch.
     if (message.text.isNotEmpty) {
       final String processedText = message.isUserMessage
           ? LocalPiiRedactionFilter.redact(message.text)
@@ -280,7 +256,6 @@ class ContextService {
       textParts.add({"type": "text", "text": processedText});
     }
 
-    // 2. Attachment Content
     if (includeImage && message.hasAttachments) {
       for (final path in message.attachmentPaths) {
         if (_isImageFile(path) ||

--- a/lib/chat/services/context.dart
+++ b/lib/chat/services/context.dart
@@ -47,6 +47,7 @@ class ContextService {
 
     // Read the system role from the session provider.
     String? systemRole = _sessionProvider.role;
+    String? runtimeIdentityDirective;
 
     final String fallbackRole =
         localizations?.systemRoleFallback ?? "You are a helpful assistant.";
@@ -97,10 +98,9 @@ class ContextService {
           targetModelId == 'cortex/auto' ||
           targetModelId == 'dynamic';
 
-      String identityDirective;
       if (isDynamicIdentity) {
-        identityDirective =
-            "\n\n[Runtime identity]\nYou are Cortex Dynamic Chat. The underlying provider may be selected automatically per request. If the user asks which model you are, identify yourself as Cortex Dynamic Chat and do not invent or claim a specific OpenAI, Anthropic, Meta, Google, or other provider model.";
+        runtimeIdentityDirective =
+            "[Runtime identity]\nYou are Cortex Dynamic Chat. The underlying provider may be selected automatically per request. If the user asks which model you are, identify yourself as Cortex Dynamic Chat and do not invent or claim a specific OpenAI, Anthropic, Meta, Google, or other provider model.";
       } else {
         final targetModel =
             _modelService.getPreciseModelData(targetModelId, langCode: langCode);
@@ -111,10 +111,9 @@ class ContextService {
                 !title.toLowerCase().startsWith(producer.toLowerCase())
             ? '$producer $title'
             : title;
-        identityDirective =
-            "\n\n[Runtime identity]\nYou are currently running as ${identity.isEmpty ? targetModel.id : identity} (model id: ${targetModel.id}). If the user asks which model you are, use this runtime identity. Never claim to be a different model or provider based on training data, prior assistant messages, or guesses.";
+        runtimeIdentityDirective =
+            "[Runtime identity]\nYou are currently running as ${identity.isEmpty ? targetModel.id : identity} (model id: ${targetModel.id}). If the user asks which model you are, use this runtime identity. Never claim to be a different model or provider based on training data, prior assistant messages, or guesses.";
       }
-      systemRole = (systemRole ?? fallbackRole) + identityDirective;
     }
 
     // Thinking mode
@@ -173,9 +172,18 @@ class ContextService {
           modality: 'image',
         );
 
-    // Hard system prompt character budget. Apply the budget before adding the
-    // system message so the actual payload is bounded too.
+    // Hard system prompt character budget. Reserve room for the runtime identity
+    // so it cannot be truncated away by a long persona/memory prompt.
     const int systemBudget = 2500;
+    if (runtimeIdentityDirective != null) {
+      final reserved = runtimeIdentityDirective.length + 2;
+      final baseBudget = (systemBudget - reserved).clamp(0, systemBudget);
+      final base = systemRole ?? fallbackRole;
+      systemRole = base.length > baseBudget
+          ? base.substring(0, baseBudget)
+          : base;
+      systemRole = '$systemRole\n\n$runtimeIdentityDirective';
+    }
     if (systemRole != null && systemRole.length > systemBudget) {
       systemRole = systemRole.substring(0, systemBudget);
     }
@@ -228,13 +236,27 @@ class ContextService {
       compressedPromptLength: compressedLength,
     );
 
-    // Safety check: Filter out empty messages
-    return compressedMessages.where((m) {
+    // Safety check: Filter out empty messages.
+    final result = compressedMessages.where((m) {
       final content = m['content'];
       if (content is String) return content.isNotEmpty;
       if (content is List) return content.isNotEmpty;
       return false;
     }).toList();
+
+    // OfflineService converts only user/assistant history turns into the native
+    // llama prompt and intentionally ignores ContextService's system entry.
+    // Repeat the small runtime identity as the final context instruction for
+    // offline models so a local Llama/Qwen/etc. cannot claim to be GPT/Claude
+    // merely because of its training data. This is not added for online calls.
+    if (!isServerSide && runtimeIdentityDirective != null) {
+      result.add({
+        "role": "user",
+        "content": runtimeIdentityDirective,
+      });
+    }
+
+    return result;
   }
 
   /// Helper function to convert a single `Message` object to the required

--- a/lib/chat/services/context.dart
+++ b/lib/chat/services/context.dart
@@ -45,17 +45,20 @@ class ContextService {
   }) async {
     final List<Map<String, dynamic>> contextMessages = [];
 
+    // Read the system role from the session provider.
     String? systemRole = _sessionProvider.role;
     String? runtimeIdentityDirective;
 
     final String fallbackRole =
         localizations?.systemRoleFallback ?? "You are a helpful assistant.";
 
+    // Language instruction FIRST to prevent English-heavy blocks below from priming the model
     if (localizations != null) {
       systemRole = (systemRole ?? fallbackRole) +
           localizations.systemLanguageInstruction;
     }
 
+    // Inject current date and time for non-character models
     if (localizations != null && !isCharacterModel) {
       final now = DateTime.now();
       final formattedTime = DateFormat.yMMMd(langCode).add_Hm().format(now);
@@ -63,11 +66,13 @@ class ContextService {
           localizations.systemTimeInfo(formattedTime);
     }
 
+    // User memory - short, relevant facts only
     if (isServerSide && userMemory != null && userMemory.trim().isNotEmpty) {
       final memoryPrompt = "\n\n[User Memory]\n$userMemory";
       systemRole = (systemRole ?? fallbackRole) + memoryPrompt;
     }
 
+    // Custom instruction (Intelligence)
     if (customInstruction != null &&
         customInstruction.trim().isNotEmpty &&
         localizations != null) {
@@ -76,15 +81,18 @@ class ContextService {
       systemRole = (systemRole ?? fallbackRole) + instructionPrompt;
     }
 
+    // Brief tone/style instruction
     if (!isCharacterModel) {
       const toneDirective =
           "\n\nBe natural, conversational and direct. Avoid poetic or dramatic language unless asked.";
       systemRole = (systemRole ?? fallbackRole) + toneDirective;
     }
 
-    // Model IDs stored on assistant messages are presentation/storage metadata.
-    // Keep the model's runtime identity out of conversation history and define it
-    // once from the actual model selected for this request.
+    // Keep model identity deterministic. Model IDs stored on old assistant
+    // messages are UI metadata and must never be used as conversational text.
+    // Dynamic Chat intentionally hides the provider selected for an individual
+    // request, so it identifies itself as Cortex rather than hallucinating a
+    // provider/model name.
     if (!isCharacterModel) {
       final isDynamicIdentity = _sessionProvider.isDynamicChat ||
           targetModelId == 'cortex/auto' ||
@@ -108,12 +116,15 @@ class ContextService {
       }
     }
 
+    // Thinking mode
     if (enableThinkingMode && localizations != null) {
       final thinkingInstruction =
           "\n\n${localizations.thinkingModeInstruction}";
       systemRole = (systemRole ?? fallbackRole) + thinkingInstruction;
     }
 
+    // Read the message list from the conversation provider and filter for valid context.
+    // We specifically exclude messages that are not visible to the user (e.g., pre-input prompts).
     List<Message> history = _conversationProvider.messages
         .where((m) =>
             m.includeInContext && !m.isThinking && !m.isError && m.isVisible)
@@ -123,6 +134,7 @@ class ContextService {
 
     final bool isLowEnd = _isLowEndModel(targetModelId);
 
+    // Memory extraction: only after meaningful conversation (3+ user messages)
     if (isServerSide && !isCharacterModel && userMessageCount >= 3) {
       final extractionInstruction = localizations != null
           ? localizations.systemMemoryDirective
@@ -130,6 +142,7 @@ class ContextService {
       systemRole = (systemRole ?? fallbackRole) + extractionInstruction;
     }
 
+    // Retrieve related context from past conversations
     String? lastUserText;
     if (history.isNotEmpty) {
       final lastUserMsg =
@@ -159,6 +172,8 @@ class ContextService {
           modality: 'image',
         );
 
+    // Hard system prompt character budget. Reserve room for the runtime identity
+    // so it cannot be truncated away by a long persona/memory prompt.
     const int systemBudget = 2500;
     if (runtimeIdentityDirective != null) {
       final reserved = runtimeIdentityDirective.length + 2;
@@ -174,10 +189,13 @@ class ContextService {
       systemRole = systemRole.substring(0, systemBudget);
     }
 
+    // Add the system prompt to the context, if it exists.
     if (systemRole != null && systemRole.isNotEmpty) {
       contextMessages.add({"role": "system", "content": systemRole});
     }
 
+    // If we're regenerating a response, exclude the last user message
+    // because it will be added again by the SendService.
     if (!includeLastUser && history.isNotEmpty) {
       final int lastUserMessageIndex =
           history.lastIndexWhere((m) => m.isUserMessage);
@@ -186,6 +204,7 @@ class ContextService {
       }
     }
 
+    // Loop through the filtered history and format each message into the API's required JSON structure.
     for (final message in history) {
       contextMessages.addAll(await _formatMessagesToJson(
         message,
@@ -218,6 +237,7 @@ class ContextService {
       compressedPromptLength: compressedLength,
     );
 
+    // Safety check: Filter out empty messages.
     final result = compressedMessages.where((m) {
       final content = m['content'];
       if (content is String) return content.isNotEmpty;
@@ -225,10 +245,11 @@ class ContextService {
       return false;
     }).toList();
 
-    // OfflineService intentionally converts only user/assistant history turns
-    // into the native llama prompt. Carry the runtime identity as the final
-    // offline context instruction so local models cannot self-identify from
-    // their training data instead of the model Cortex actually loaded.
+    // OfflineService converts only user/assistant history turns into the native
+    // llama prompt and intentionally ignores ContextService's system entry.
+    // Repeat the small runtime identity as the final context instruction for
+    // offline models so a local Llama/Qwen/etc. cannot claim to be GPT/Claude
+    // merely because of its training data. This is not added for online calls.
     if (!isServerSide && runtimeIdentityDirective != null) {
       result.add({
         "role": "user",
@@ -239,6 +260,9 @@ class ContextService {
     return result;
   }
 
+  /// Helper function to convert a single `Message` object to the required
+  /// multimodal JSON format. If the assistant generated an image, we split it
+  /// into a separate synthetic user message so the vision API accepts it.
   Future<List<Map<String, dynamic>>> _formatMessagesToJson(Message message,
       {required bool includeImage,
       required bool includeAllMedia,
@@ -247,8 +271,9 @@ class ContextService {
     List<Map<String, dynamic>> textParts = [];
     List<Map<String, dynamic>> mediaParts = [];
 
-    // `message.model` is UI/storage metadata, not dialogue. Prefixing it into
-    // assistant content contaminates the next model after a model switch.
+    // 1. Text Content. `message.model` is UI/storage metadata, not dialogue.
+    // Prefixing it into assistant text causes cross-model identity contamination
+    // when the user switches from e.g. Cortex to Llama or Claude.
     if (message.text.isNotEmpty) {
       final String processedText = message.isUserMessage
           ? LocalPiiRedactionFilter.redact(message.text)
@@ -256,6 +281,7 @@ class ContextService {
       textParts.add({"type": "text", "text": processedText});
     }
 
+    // 2. Attachment Content
     if (includeImage && message.hasAttachments) {
       for (final path in message.attachmentPaths) {
         if (_isImageFile(path) ||

--- a/lib/chat/services/utils.dart
+++ b/lib/chat/services/utils.dart
@@ -85,7 +85,6 @@ class Utils {
         final mimeType = lookupMimeType(mediaPath, headerBytes: mediaBytes) ??
             'application/octet-stream';
 
-        // Ensure it's media (we optionally could restrict down to mp4, wav, etc.)
         if (!mimeType.startsWith('image/') &&
             !mimeType.startsWith('video/') &&
             !mimeType.startsWith('audio/')) {
@@ -100,6 +99,22 @@ class Utils {
       debugPrint("Error reading or encoding media file: $e");
     }
     return null;
+  }
+
+  /// Reads only enough bytes for MIME sniffing. Some Android/iOS picker cache
+  /// files have generic or missing extensions even though they contain a valid
+  /// image. Relying only on the path can therefore make a visible attachment
+  /// disappear from the API payload.
+  static Future<List<int>> _readMimeProbe(File file) async {
+    RandomAccessFile? handle;
+    try {
+      handle = await file.open();
+      return await handle.read(512);
+    } catch (_) {
+      return const <int>[];
+    } finally {
+      await handle?.close();
+    }
   }
 
   /// Processes an attachment path and returns the correct OpenAI-compatible content block.
@@ -132,25 +147,40 @@ class Utils {
       }
 
       final file = File(path);
-      if (!await file.exists()) return null;
+      if (!await file.exists()) {
+        debugPrint("[Utils] Attachment no longer exists: $path");
+        return null;
+      }
 
-      final mimeType = lookupMimeType(path) ?? 'application/octet-stream';
-      final String fileName = path.split('/').last;
-      final String extension = fileName.split('.').last.toLowerCase();
+      final mimeProbe = await _readMimeProbe(file);
+      final mimeType = lookupMimeType(
+            path,
+            headerBytes: mimeProbe.isEmpty ? null : mimeProbe,
+          ) ??
+          'application/octet-stream';
+      final String fileName = file.uri.pathSegments.isNotEmpty
+          ? file.uri.pathSegments.last
+          : path.split('/').last;
+      final int dotIndex = fileName.lastIndexOf('.');
+      final String extension = dotIndex >= 0 && dotIndex < fileName.length - 1
+          ? fileName.substring(dotIndex + 1).toLowerCase()
+          : '';
 
-      // 1. Handle Media (Images, Video, Audio) - send as base64 data URL
+      // 1. Handle Media (Images, Video, Audio) - send as base64 data URL.
+      // MIME is sniffed from file bytes so picker-cache paths without a useful
+      // extension still reach vision-capable models.
       if (mimeType.startsWith('image/') ||
           mimeType.startsWith('video/') ||
           mimeType.startsWith('audio/')) {
         final base64Url = await formatBase64Media(path);
         if (base64Url != null) {
-          // OpenRouter/OpenAI structure uses "image_url" conventionally
-          // Fal.ai and custom Vertex routing will pull the URL from this object
           return {
             "type": "image_url",
             "image_url": {"url": base64Url}
           };
         }
+        debugPrint("[Utils] Failed to encode media attachment: $path");
+        return null;
       }
 
       // 2. Text-based files - read directly (no tool needed)

--- a/lib/library/backend/data/entity.dart
+++ b/lib/library/backend/data/entity.dart
@@ -43,84 +43,34 @@ class ModelEntity {
       }
     }
 
-    // Strip lone leading/trailing formatting chars
     result = result.replaceAll(_loneLeadingQuotes, '');
     result = result.replaceAll(_loneTrailingQuotes, '');
     return result.trim();
   }
 
-  /// The unique identifier for the model (e.g., 'gpt-5', 'neuro').
   final String id;
-
-  /// The display-ready, localized title.
   final String displayTitle;
-
-  /// The series of the model.
   final String? series;
-
-  /// The name of the entity or company that produced the model.
   final String producer;
-
-  /// The type of the model (e.g., 'online', 'offline').
   final String type;
-
-  /// The source/provider of the model (e.g., 'openrouter', 'fal', 'huggingface').
   final String source;
-
-  /// The category of the model (e.g., 'roleplay', 'self', 'assistant').
   final String category;
-
-  /// The system prompt or persona definition for roleplay models.
   final String? role;
-
-  /// The display-ready, localized summary.
   final String displaySummary;
-
-  /// The display-ready, localized detailed description.
   final String displayDescription;
-
-  /// The ID of the base model this model is derived from.
   final String? baseModelId;
-
-  /// The raw path to the model's image asset (local file path, asset path, or URL).
   final String? imagePath;
-
-  /// The path to the GGUF file for offline models.
   final String? ggufPath;
-
-  /// The tier of the model (e.g., 'free', 'premium').
   final String tier;
-
-  /// The size of the model in megabytes (MB).
   final int? size;
-
-  /// The required RAM in megabytes (MB) to run the model.
   final int? ram;
-
-  /// A map defining the input modalities supported by the model (e.g., {'image': true}).
   final Map<String, dynamic> modalities;
-
-  /// A map defining the output capabilities of the model (e.g., {'text': true}).
   final Map<String, dynamic> outputs;
-
-  /// Whether the model supports tool use.
   final bool toolUse;
-
-  /// A map containing variant data for variant models.
   final Map<String, dynamic>? variants;
-
-  /// The URL for downloading the model.
   final String? url;
-
-  /// The context window or other technical context for the model (e.g., "8k", "128k").
   final String? context;
-
-  /// Indicates if all main text fields were successfully localized
-  /// for the current non-English language, or if an English fallback was used.
-  /// This is calculated and provided by the ModelRepository.
   final bool isFullyLocalized;
-
-  /// The chat format configuration for offline models.
   final ChatFormat? chatFormat;
 
   const ModelEntity({
@@ -183,6 +133,30 @@ class ModelEntity {
       return null;
     }
 
+    /// A top-level catalog entry can represent a series rather than one exact
+    /// backend model. Synapse keeps capabilities on individual variants, while
+    /// the UI asks the parent ModelEntity whether it can accept an image/audio
+    /// input. Aggregate true capabilities from every variant so those two views
+    /// cannot disagree. Explicit parent values are preserved.
+    Map<String, dynamic> aggregateModalities() {
+      final result = _safeStringKeyMap(map['modalities']);
+      final rawVariants = map['variants'];
+      if (rawVariants is! Map) return result;
+
+      for (final rawVariant in rawVariants.values) {
+        if (rawVariant is! Map) continue;
+        final variantModalities = _safeStringKeyMap(rawVariant['modalities']);
+        for (final entry in variantModalities.entries) {
+          if (entry.value == true) {
+            result[entry.key] = true;
+          } else {
+            result.putIfAbsent(entry.key, () => entry.value);
+          }
+        }
+      }
+      return result;
+    }
+
     final id = map['id']?.toString() ?? 'unknown';
     final seriesSource = getStringOrLocalized(map['series']);
     final rawTitleCandidate = getLocalizedFieldFromDetails('title') ??
@@ -227,7 +201,7 @@ class ModelEntity {
       tier: getStringOrLocalized(map['tier']) ?? 'free',
       size: int.tryParse(map['size']?.toString() ?? ''),
       ram: int.tryParse(map['ram']?.toString() ?? ''),
-      modalities: _safeStringKeyMap(map['modalities']),
+      modalities: aggregateModalities(),
       outputs: _safeStringKeyMap(map['outputs']),
       toolUse: map['toolUse'] == true,
       variants: map['variants'] is Map
@@ -270,7 +244,6 @@ class ModelEntity {
     return jsonDecode(jsonEncode(value));
   }
 
-  /// Creates a copy of this [ModelEntity] but with the given fields replaced.
   ModelEntity copyWith({
     String? id,
     String? displayTitle,
@@ -325,7 +298,6 @@ class ModelEntity {
     );
   }
 
-  /// Converts the [ModelEntity] back to a generic map.
   Map<String, dynamic> toMap() {
     return {
       'id': id,
@@ -354,15 +326,12 @@ class ModelEntity {
     };
   }
 
-  // --- Getters for convenience ---
-
   bool get isCustomModel =>
       source == 'user' || id.startsWith('self_') || id.startsWith('local_');
 
   bool get isServerSide => type != 'offline';
 
   bool get isPremium {
-    // Explicit list of premium models as requested by the user.
     final premiumKeywords = [
       'claude',
       'codex',

--- a/lib/library/backend/data/entity.dart
+++ b/lib/library/backend/data/entity.dart
@@ -43,34 +43,84 @@ class ModelEntity {
       }
     }
 
+    // Strip lone leading/trailing formatting chars
     result = result.replaceAll(_loneLeadingQuotes, '');
     result = result.replaceAll(_loneTrailingQuotes, '');
     return result.trim();
   }
 
+  /// The unique identifier for the model (e.g., 'gpt-5', 'neuro').
   final String id;
+
+  /// The display-ready, localized title.
   final String displayTitle;
+
+  /// The series of the model.
   final String? series;
+
+  /// The name of the entity or company that produced the model.
   final String producer;
+
+  /// The type of the model (e.g., 'online', 'offline').
   final String type;
+
+  /// The source/provider of the model (e.g., 'openrouter', 'fal', 'huggingface').
   final String source;
+
+  /// The category of the model (e.g., 'roleplay', 'self', 'assistant').
   final String category;
+
+  /// The system prompt or persona definition for roleplay models.
   final String? role;
+
+  /// The display-ready, localized summary.
   final String displaySummary;
+
+  /// The display-ready, localized detailed description.
   final String displayDescription;
+
+  /// The ID of the base model this model is derived from.
   final String? baseModelId;
+
+  /// The raw path to the model's image asset (local file path, asset path, or URL).
   final String? imagePath;
+
+  /// The path to the GGUF file for offline models.
   final String? ggufPath;
+
+  /// The tier of the model (e.g., 'free', 'premium').
   final String tier;
+
+  /// The size of the model in megabytes (MB).
   final int? size;
+
+  /// The required RAM in megabytes (MB) to run the model.
   final int? ram;
+
+  /// A map defining the input modalities supported by the model (e.g., {'image': true}).
   final Map<String, dynamic> modalities;
+
+  /// A map defining the output capabilities of the model (e.g., {'text': true}).
   final Map<String, dynamic> outputs;
+
+  /// Whether the model supports tool use.
   final bool toolUse;
+
+  /// A map containing variant data for variant models.
   final Map<String, dynamic>? variants;
+
+  /// The URL for downloading the model.
   final String? url;
+
+  /// The context window or other technical context for the model (e.g., "8k", "128k").
   final String? context;
+
+  /// Indicates if all main text fields were successfully localized
+  /// for the current non-English language, or if an English fallback was used.
+  /// This is calculated and provided by the ModelRepository.
   final bool isFullyLocalized;
+
+  /// The chat format configuration for offline models.
   final ChatFormat? chatFormat;
 
   const ModelEntity({
@@ -244,6 +294,7 @@ class ModelEntity {
     return jsonDecode(jsonEncode(value));
   }
 
+  /// Creates a copy of this [ModelEntity] but with the given fields replaced.
   ModelEntity copyWith({
     String? id,
     String? displayTitle,
@@ -298,6 +349,7 @@ class ModelEntity {
     );
   }
 
+  /// Converts the [ModelEntity] back to a generic map.
   Map<String, dynamic> toMap() {
     return {
       'id': id,
@@ -326,12 +378,15 @@ class ModelEntity {
     };
   }
 
+  // --- Getters for convenience ---
+
   bool get isCustomModel =>
       source == 'user' || id.startsWith('self_') || id.startsWith('local_');
 
   bool get isServerSide => type != 'offline';
 
   bool get isPremium {
+    // Explicit list of premium models as requested by the user.
     final premiumKeywords = [
       'claude',
       'codex',

--- a/lib/library/backend/data/repository.dart
+++ b/lib/library/backend/data/repository.dart
@@ -27,6 +27,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:sqflite/sqflite.dart';
+import '../security.dart';
 
 /// The [ModelRepository] class is responsible for all low-level data operations
 /// related to AI models. It abstracts the data sources from the rest of the application.
@@ -258,6 +259,12 @@ class ModelRepository {
     debugPrint("[ModelRepository] Starting full model sync with server...");
     try {
       final validPublicIds = await _fetchAndStorePublicModels(langCode);
+      if (validPublicIds == null) {
+        debugPrint(
+            "[ModelRepository] Server sync was rejected or incomplete. Preserving local catalog and last-sync state.");
+        return;
+      }
+
       debugPrint(
           "[ModelRepository] Public model sync complete. Found ${validPublicIds.length} valid IDs.");
 
@@ -274,16 +281,10 @@ class ModelRepository {
 
   /// Fetches the public model list from the remote server.
   ///
-  /// OPTIMIZATION NOTES FOR LOW-END DEVICES (ANR Prevention):
-  /// 1. **Isolate Parsing**: JSON parsing is moved to a background isolate via `compute`.
-  ///    This prevents the CPU from blocking the main thread during data processing.
-  /// 2. **Chunked Inserts**: Database writes are split into batches of 50.
-  /// 3. **UI Yielding**: After each batch commit, we `await Future.delayed(Duration.zero)`.
-  ///    This gives the UI thread a chance to render frames and handle events, preventing
-  ///    "Application Not Responding" errors on slow storage devices.
-  /// 4. **Deferred Vacuum**: Database optimization is performed only after all writes are done
-  ///    and after a brief cooling period.
-  Future<Set<String>> _fetchAndStorePublicModels(String langCode) async {
+  /// Returns null when the remote response cannot be trusted as a complete,
+  /// successful catalog. Null prevents stale cleanup and prevents the client from
+  /// advancing its last-successful-sync timestamp.
+  Future<Set<String>?> _fetchAndStorePublicModels(String langCode) async {
     try {
       final response = await _dio.get<Map<String, dynamic>>(
         _serverUrl,
@@ -297,23 +298,28 @@ class ModelRepository {
       if (response.statusCode != 200) {
         debugPrint(
             "[ModelRepository] Server returned status ${response.statusCode}. Skipping sync.");
-        return <String>{};
+        return null;
       }
 
       if (response.data == null) {
         debugPrint("[ModelRepository] Server returned empty data.");
-        return <String>{};
+        return null;
       }
 
       final rawServerData = response.data!;
 
-      // 1. Offload heavy JSON parsing to a background isolate.
       debugPrint(
           "[ModelRepository] Parsing server data in background isolate...");
       final parsedServerModels = await compute(
         _parseServerDataIsolate,
         {'data': rawServerData, 'langCode': langCode},
       );
+
+      if (parsedServerModels.isEmpty) {
+        debugPrint(
+            "[ModelRepository] Parsed catalog is empty. Treating response as incomplete.");
+        return null;
+      }
 
       final parsedFallbackModels = await compute(
         _parseServerDataIsolate,
@@ -326,64 +332,90 @@ class ModelRepository {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString('fallback', json.encode(parsedFallbackModels));
 
-      final validServerIds =
-          parsedServerModels.map((m) => m['id']?.toString() ?? '').toSet();
-
-      // Filter out local/custom models just in case the server sent something weird.
+      // Filter out local/custom IDs and malformed entries. A remote catalog must
+      // never impersonate user-created/local model namespaces.
       final modelsToInsert = parsedServerModels.where((modelData) {
-        return !modelData['id'].startsWith('self_') &&
-            !modelData['id'].startsWith('local_');
+        final id = modelData['id']?.toString().trim() ?? '';
+        return id.isNotEmpty &&
+            !id.startsWith('self_') &&
+            !id.startsWith('local_');
       }).toList();
 
-      if (modelsToInsert.isNotEmpty) {
-        final db = await _dbHelper.database;
-        if (db != null) {
-          const int batchSize = 50; // Optimal chunk size to prevent locking
+      if (modelsToInsert.isEmpty) {
+        debugPrint(
+            "[ModelRepository] No valid public models remained after validation.");
+        return null;
+      }
 
-          for (var i = 0; i < modelsToInsert.length; i += batchSize) {
-            final end = (i + batchSize < modelsToInsert.length)
-                ? i + batchSize
-                : modelsToInsert.length;
-            final currentBatch = modelsToInsert.sublist(i, end);
+      final currentModels =
+          await _dbHelper.getAllModels(userId: _auth.currentUser?.uid);
+      final existingPublicCount = currentModels.where((model) {
+        final id = model['id']?.toString() ?? '';
+        return id.isNotEmpty &&
+            !id.startsWith('self_') &&
+            !id.startsWith('local_');
+      }).length;
 
-            final batch = db.batch();
+      if (!ModelSecurity.isPlausibleCatalogReplacement(
+        existingCount: existingPublicCount,
+        incomingCount: modelsToInsert.length,
+      )) {
+        debugPrint(
+            "[ModelRepository] Catalog shrink guard rejected ${modelsToInsert.length} incoming models against $existingPublicCount existing public models.");
+        return null;
+      }
 
-            for (var modelData in currentBatch) {
-              batch.insert(
-                  'models',
-                  {
-                    'id': modelData['id'],
-                    'producer': modelData['producer'] ?? 'Unknown',
-                    'title': modelData['title'] ?? modelData['id'],
-                    'is_server_side': (modelData['type'] != 'offline') ? 1 : 0,
-                    'type': modelData['type'] ?? 'online',
-                    'raw_json': json.encode(modelData),
-                  },
-                  conflictAlgorithm: ConflictAlgorithm.replace);
-            }
+      final validServerIds = modelsToInsert
+          .map((model) => model['id']?.toString().trim() ?? '')
+          .where((id) => id.isNotEmpty)
+          .toSet();
 
-            try {
-              await batch.commit(noResult: true);
+      var writeFailed = false;
+      final db = await _dbHelper.database;
+      if (db != null) {
+        const int batchSize = 50; // Optimal chunk size to prevent locking
 
-              // 2. Yield to the UI thread to prevent ANRs on slow devices.
-              await Future.delayed(Duration.zero);
-            } catch (e) {
-              if (e.toString().contains("SQLITE_FULL")) {
-                debugPrint(
-                    "[ModelRepository] DISK FULL. Aborting model sync save.");
-                break;
-              } else {
-                rethrow;
-              }
+        for (var i = 0; i < modelsToInsert.length; i += batchSize) {
+          final end = (i + batchSize < modelsToInsert.length)
+              ? i + batchSize
+              : modelsToInsert.length;
+          final currentBatch = modelsToInsert.sublist(i, end);
+
+          final batch = db.batch();
+
+          for (var modelData in currentBatch) {
+            batch.insert(
+                'models',
+                {
+                  'id': modelData['id'],
+                  'producer': modelData['producer'] ?? 'Unknown',
+                  'title': modelData['title'] ?? modelData['id'],
+                  'is_server_side': (modelData['type'] != 'offline') ? 1 : 0,
+                  'type': modelData['type'] ?? 'online',
+                  'raw_json': json.encode(modelData),
+                },
+                conflictAlgorithm: ConflictAlgorithm.replace);
+          }
+
+          try {
+            await batch.commit(noResult: true);
+            await Future.delayed(Duration.zero);
+          } catch (e) {
+            if (e.toString().contains("SQLITE_FULL")) {
+              debugPrint(
+                  "[ModelRepository] DISK FULL. Aborting model sync save without advancing sync state.");
+              writeFailed = true;
+              break;
+            } else {
+              rethrow;
             }
           }
         }
       }
 
-      // 3. Allow UI to breathe before the heavy VACUUM operation.
-      await Future.delayed(const Duration(milliseconds: 100));
+      if (writeFailed) return null;
 
-      // 4. Perform database optimization.
+      await Future.delayed(const Duration(milliseconds: 100));
       await _dbHelper.optimizeDatabase();
 
       return validServerIds;
@@ -393,7 +425,7 @@ class ModelRepository {
             "[ModelRepository] Server Error (500). Using local cache instead.");
         FirebaseCrashlytics.instance
             .log("Server 500 error on model sync. Skipping.");
-        return <String>{};
+        return null;
       }
 
       final errorString = e.toString();
@@ -401,7 +433,7 @@ class ModelRepository {
           errorString.contains("HandshakeException")) {
         debugPrint(
             "[ModelRepository] SSL/Certificate Error detected (Likely user network issue). Using local cache.");
-        return <String>{};
+        return null;
       }
 
       if (e.type == DioExceptionType.connectionTimeout ||
@@ -411,18 +443,18 @@ class ModelRepository {
           e.error is SocketException) {
         debugPrint(
             "[ModelRepository] Network timeout or connection error (${e.type}). Using local cache.");
-        return <String>{};
+        return null;
       }
 
       debugPrint("[ModelRepository] Unexpected DioException: $e");
       FirebaseCrashlytics.instance
           .recordError(e, s, reason: 'Failed to sync public models');
-      return <String>{};
+      return null;
     } catch (e, s) {
       debugPrint("[ModelRepository] Generic error: $e");
       FirebaseCrashlytics.instance
           .recordError(e, s, reason: 'Unexpected failure in public model sync');
-      return <String>{};
+      return null;
     }
   }
 
@@ -730,7 +762,7 @@ class ModelRepository {
         if (model != null) finalList.add(model);
       }
     }
-    return finalList;
+    return ModelSecurity.disambiguateDuplicateModelIds(finalList);
   }
 
   static Map<String, dynamic>? _staticParseSingleVariantModel(String seriesName,
@@ -820,6 +852,8 @@ class ModelRepository {
       if (variantData is! Map<String, dynamic>) continue;
 
       final cleanVariantData = _staticSanitizeRawData(variantData);
+      final variantId = cleanVariantData['id']?.toString().trim() ?? '';
+      if (variantId.isEmpty) continue;
 
       final descriptionMap = _safeStringKeyMap(cleanVariantData['description']);
 
@@ -829,9 +863,9 @@ class ModelRepository {
       final bool isVariantLocalized = (_normalizedLangCode(langCode) == 'en') ||
           _hasLocalizedString(descriptionMap, langCode);
 
-      variants[cleanVariantData['id'] as String] = {
+      variants[variantId] = {
         ...cleanVariantData,
-        'id': cleanVariantData['id'],
+        'id': variantId,
         'title': cleanVariantData['title'] ?? variantKey,
         'summary': localizedSeriesSummary,
         'description': localizedVariantDescription,

--- a/lib/library/backend/download/download.dart
+++ b/lib/library/backend/download/download.dart
@@ -8,6 +8,7 @@ import 'package:flutter_downloader/flutter_downloader.dart';
 import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import '../security.dart';
 
 class DownloadManager extends ChangeNotifier {
   bool isDownloading = false;
@@ -141,6 +142,22 @@ class FileDownloadHelper extends ChangeNotifier {
           } else if (dstatus == DownloadTaskStatus.enqueued) {
             // Do nothing
           } else if (dstatus == DownloadTaskStatus.complete) {
+            final downloadedFile = File(taskInfo.filePath);
+            final isValid = await ModelSecurity.isValidGgufFile(downloadedFile);
+            if (!isValid) {
+              if (await downloadedFile.exists()) {
+                try {
+                  await downloadedFile.delete();
+                } catch (_) {}
+              }
+              taskInfo.onDownloadError(
+                  'Downloaded file is not a valid GGUF model.');
+              _tasks.remove(taskId);
+              debugPrint(
+                  "[FileDownloadHelper] Rejected invalid GGUF download for '${taskInfo.modelId}'.");
+              return;
+            }
+
             taskInfo.onDownloadCompleted(taskId);
             _tasks.remove(taskId);
             debugPrint(
@@ -209,6 +226,8 @@ class FileDownloadHelper extends ChangeNotifier {
     required bool showNotification,
   }) async {
     try {
+      final safeUrl = ModelSecurity.requireTrustedDownloadUri(url).toString();
+
       _status = 'Downloading';
       refresh();
 
@@ -236,7 +255,7 @@ class FileDownloadHelper extends ChangeNotifier {
       if (!useDioFallback) {
         try {
           taskId = await FlutterDownloader.enqueue(
-            url: url,
+            url: safeUrl,
             savedDir: savedDir,
             fileName: fileName,
             showNotification: showNotification,
@@ -263,7 +282,7 @@ class FileDownloadHelper extends ChangeNotifier {
           taskId: taskId,
           title: title,
           filePath: filePath,
-          url: url,
+          url: safeUrl,
           cancelToken: cancelToken,
           isDioFallback: true,
           onProgress: onProgress,
@@ -279,7 +298,7 @@ class FileDownloadHelper extends ChangeNotifier {
           taskId: taskId,
           title: title,
           filePath: filePath,
-          url: url,
+          url: safeUrl,
           onProgress: onProgress,
           onDownloadCompleted: onDownloadCompleted,
           onDownloadError: onDownloadError,
@@ -326,6 +345,11 @@ class FileDownloadHelper extends ChangeNotifier {
       );
 
       final tempFile = File(tempFilePath);
+      if (!await ModelSecurity.isValidGgufFile(tempFile)) {
+        if (await tempFile.exists()) await tempFile.delete();
+        throw StateError('Downloaded file is not a valid GGUF model.');
+      }
+
       if (await tempFile.exists()) {
         await tempFile.rename(taskInfo.filePath);
       }

--- a/lib/library/backend/security.dart
+++ b/lib/library/backend/security.dart
@@ -1,0 +1,178 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+
+/// Security and consistency checks for data received from the model catalog.
+///
+/// Synapse is a remote data source. Even though it is operated by Cortex, the
+/// mobile client must treat catalog fields as untrusted input before using them
+/// as URLs, file-system paths, or destructive synchronization state.
+class ModelSecurity {
+  static const List<int> _ggufMagic = <int>[0x47, 0x47, 0x55, 0x46]; // GGUF
+
+  /// Accepts only HTTPS URLs that resolve to a public host.
+  ///
+  /// This prevents catalog entries from making the device fetch clear-text,
+  /// loopback, link-local, or private-network resources.
+  static Uri requireTrustedDownloadUri(String rawUrl) {
+    final uri = Uri.tryParse(rawUrl.trim());
+    if (uri == null ||
+        uri.scheme.toLowerCase() != 'https' ||
+        uri.host.isEmpty ||
+        uri.userInfo.isNotEmpty) {
+      throw const FormatException('Model download URL must be a valid HTTPS URL.');
+    }
+
+    if (_isBlockedHost(uri.host)) {
+      throw const FormatException('Model download URL points to a local or private host.');
+    }
+
+    return uri;
+  }
+
+  /// Resolves a model ID to a path that can never escape [filesDir].
+  ///
+  /// Existing safe/legacy IDs keep their current path. Only an ID that would
+  /// traverse outside the model directory is mapped to a deterministic digest
+  /// filename, preserving app stability without trusting the unsafe path text.
+  static String resolveModelFilePath({
+    required String filesDir,
+    required String modelId,
+  }) {
+    if (filesDir.trim().isEmpty) {
+      throw ArgumentError.value(filesDir, 'filesDir', 'must not be empty');
+    }
+    if (modelId.trim().isEmpty) {
+      throw ArgumentError.value(modelId, 'modelId', 'must not be empty');
+    }
+
+    final base = p.normalize(p.absolute(filesDir));
+    final candidate =
+        p.normalize(p.absolute(p.join(base, '${modelId.trim()}.gguf')));
+
+    if (p.isWithin(base, candidate)) {
+      return candidate;
+    }
+
+    final digest = sha256.convert(utf8.encode(modelId)).toString().substring(0, 32);
+    return p.join(base, 'model_$digest.gguf');
+  }
+
+  /// Validates the GGUF magic header before the app marks a model downloaded.
+  static Future<bool> isValidGgufFile(File file) async {
+    try {
+      if (!await file.exists() || await file.length() < _ggufMagic.length) {
+        return false;
+      }
+
+      final handle = await file.open();
+      try {
+        final header = await handle.read(_ggufMagic.length);
+        if (header.length != _ggufMagic.length) return false;
+        for (var i = 0; i < _ggufMagic.length; i++) {
+          if (header[i] != _ggufMagic[i]) return false;
+        }
+        return true;
+      } finally {
+        await handle.close();
+      }
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Rejects suspiciously large catalog drops before stale-model cleanup.
+  ///
+  /// Small catalogs during first-run/development are allowed. Once the client
+  /// already has a meaningful catalog, a response containing less than half of
+  /// the existing public entries is treated as partial/corrupt and retried later.
+  static bool isPlausibleCatalogReplacement({
+    required int existingCount,
+    required int incomingCount,
+  }) {
+    if (incomingCount <= 0) return false;
+    if (existingCount < 20) return true;
+    return incomingCount >= (existingCount * 0.5).ceil();
+  }
+
+  /// Makes top-level catalog IDs unique without changing non-conflicting IDs.
+  ///
+  /// Multi-variant series historically derive their top-level ID from only the
+  /// series name, so two producers can otherwise overwrite one another in the
+  /// SQLite table where `id` is the primary key.
+  static List<Map<String, dynamic>> disambiguateDuplicateModelIds(
+      List<Map<String, dynamic>> models) {
+    final counts = <String, int>{};
+    for (final model in models) {
+      final id = model['id']?.toString().trim() ?? '';
+      if (id.isNotEmpty) counts[id] = (counts[id] ?? 0) + 1;
+    }
+
+    final used = <String>{};
+    final result = <Map<String, dynamic>>[];
+
+    for (final source in models) {
+      final model = Map<String, dynamic>.from(source);
+      final originalId = model['id']?.toString().trim() ?? '';
+      if (originalId.isEmpty) continue;
+
+      var finalId = originalId;
+      if ((counts[originalId] ?? 0) > 1) {
+        final producer = _slug(model['producer']?.toString() ?? 'producer');
+        final idSlug = _slug(originalId);
+        final prefix = producer.isEmpty ? 'producer' : producer;
+        final suffix = idSlug.isEmpty ? 'model' : idSlug;
+        finalId = '$prefix--$suffix';
+      }
+
+      var uniqueId = finalId;
+      var n = 2;
+      while (used.contains(uniqueId)) {
+        uniqueId = '$finalId-$n';
+        n++;
+      }
+      used.add(uniqueId);
+      model['id'] = uniqueId;
+      result.add(model);
+    }
+
+    return result;
+  }
+
+  static bool _isBlockedHost(String rawHost) {
+    final host = rawHost.toLowerCase().replaceAll(RegExp(r'^\[|\]$'), '');
+    if (host == 'localhost' ||
+        host.endsWith('.localhost') ||
+        host.endsWith('.local') ||
+        host == '::1' ||
+        host.startsWith('fc') ||
+        host.startsWith('fd') ||
+        host.startsWith('fe80:')) {
+      return true;
+    }
+
+    final parts = host.split('.');
+    if (parts.length != 4) return false;
+    final octets = parts.map(int.tryParse).toList();
+    if (octets.any((value) => value == null || value < 0 || value > 255)) {
+      return false;
+    }
+
+    final a = octets[0]!;
+    final b = octets[1]!;
+    return a == 10 ||
+        a == 127 ||
+        (a == 169 && b == 254) ||
+        (a == 172 && b >= 16 && b <= 31) ||
+        (a == 192 && b == 168) ||
+        a == 0;
+  }
+
+  static String _slug(String value) => value
+      .trim()
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+      .replaceAll(RegExp(r'^-+|-+$'), '');
+}

--- a/lib/library/backend/security.dart
+++ b/lib/library/backend/security.dart
@@ -160,7 +160,12 @@ class ModelSecurity {
     if (parts.length != 4) return false;
     final octets = parts.map(int.tryParse).toList();
     if (octets.any((value) => value == null)) return false;
-    if (octets.any((value) => value! < 0 || value > 255)) return false;
+    if (octets.any((value) {
+      final octet = value!;
+      return octet < 0 || octet > 255;
+    })) {
+      return false;
+    }
 
     final a = octets[0]!;
     final b = octets[1]!;

--- a/lib/library/backend/security.dart
+++ b/lib/library/backend/security.dart
@@ -143,22 +143,24 @@ class ModelSecurity {
 
   static bool _isBlockedHost(String rawHost) {
     final host = rawHost.toLowerCase().replaceAll(RegExp(r'^\[|\]$'), '');
+    final isIpv6Literal = host.contains(':');
+
     if (host == 'localhost' ||
         host.endsWith('.localhost') ||
         host.endsWith('.local') ||
         host == '::1' ||
-        host.startsWith('fc') ||
-        host.startsWith('fd') ||
-        host.startsWith('fe80:')) {
+        (isIpv6Literal &&
+            (host.startsWith('fc') ||
+                host.startsWith('fd') ||
+                host.startsWith('fe80:')))) {
       return true;
     }
 
     final parts = host.split('.');
     if (parts.length != 4) return false;
     final octets = parts.map(int.tryParse).toList();
-    if (octets.any((value) => value == null || value < 0 || value > 255)) {
-      return false;
-    }
+    if (octets.any((value) => value == null)) return false;
+    if (octets.any((value) => value! < 0 || value > 255)) return false;
 
     final a = octets[0]!;
     final b = octets[1]!;

--- a/lib/library/backend/utils.dart
+++ b/lib/library/backend/utils.dart
@@ -20,6 +20,7 @@ import 'package:cortex/library/backend/system.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'data/user.dart';
+import 'security.dart';
 
 /// Describes the compatibility of a model with the current device's hardware.
 enum CompatibilityStatus {
@@ -106,7 +107,10 @@ class ModelsBackendUtils {
     assert(filesDir.isNotEmpty, 'filesDir must not be empty');
     assert(modelId.isNotEmpty, 'modelId must not be empty');
 
-    final fullPath = p.join(filesDir, '$modelId.gguf');
+    final fullPath = ModelSecurity.resolveModelFilePath(
+      filesDir: filesDir,
+      modelId: modelId,
+    );
 
     dev.log(
       '[CANONICAL_PATH] getFilePathById(id: $modelId) → $fullPath',

--- a/test/synapse_client_hardening_test.dart
+++ b/test/synapse_client_hardening_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:cortex/chat/services/utils.dart';
 import 'package:cortex/library/backend/security.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
@@ -102,5 +103,42 @@ void main() {
     final invalid = File(p.join(dir.path, 'invalid.gguf'));
     await invalid.writeAsBytes([0x50, 0x4b, 0x03, 0x04]);
     expect(await ModelSecurity.isValidGgufFile(invalid), isFalse);
+  });
+
+  test('detects picker images from bytes even without a file extension', () async {
+    final dir = await Directory.systemTemp.createTemp('cortex_image_test_');
+    addTearDown(() async {
+      if (await dir.exists()) {
+        await dir.delete(recursive: true);
+      }
+    });
+
+    // PNG signature followed by a small dummy payload. The app only needs MIME
+    // detection/base64 encoding here; it is not decoding pixels in this helper.
+    final extensionless = File(p.join(dir.path, 'picker_cache_item'));
+    await extensionless.writeAsBytes([
+      0x89,
+      0x50,
+      0x4E,
+      0x47,
+      0x0D,
+      0x0A,
+      0x1A,
+      0x0A,
+      0x00,
+      0x00,
+      0x00,
+      0x0D,
+      0x49,
+      0x48,
+      0x44,
+      0x52,
+    ]);
+
+    final block = await Utils.processAttachment(extensionless.path);
+    expect(block, isNotNull);
+    expect(block!['type'], 'image_url');
+    final imageUrl = block['image_url'] as Map<String, dynamic>;
+    expect(imageUrl['url'], startsWith('data:image/png;base64,'));
   });
 }

--- a/test/synapse_client_hardening_test.dart
+++ b/test/synapse_client_hardening_test.dart
@@ -11,6 +11,10 @@ void main() {
           'https://huggingface.co/org/model/resolve/main/model.gguf');
       expect(uri.scheme, 'https');
       expect(uri.host, 'huggingface.co');
+
+      final fcDomain = ModelSecurity.requireTrustedDownloadUri(
+          'https://fcdn.example.com/model.gguf');
+      expect(fcDomain.host, 'fcdn.example.com');
     });
 
     test('rejects clear-text and private hosts', () {
@@ -85,7 +89,11 @@ void main() {
 
   test('validates GGUF magic bytes', () async {
     final dir = await Directory.systemTemp.createTemp('cortex_gguf_test_');
-    addTearDown(() => dir.delete(recursive: true));
+    addTearDown(() async {
+      if (await dir.exists()) {
+        await dir.delete(recursive: true);
+      }
+    });
 
     final valid = File(p.join(dir.path, 'valid.gguf'));
     await valid.writeAsBytes([0x47, 0x47, 0x55, 0x46, 0, 0, 0, 0]);

--- a/test/synapse_client_hardening_test.dart
+++ b/test/synapse_client_hardening_test.dart
@@ -1,0 +1,98 @@
+import 'dart:io';
+
+import 'package:cortex/library/backend/security.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('ModelSecurity download URL validation', () {
+    test('accepts public HTTPS URLs', () {
+      final uri = ModelSecurity.requireTrustedDownloadUri(
+          'https://huggingface.co/org/model/resolve/main/model.gguf');
+      expect(uri.scheme, 'https');
+      expect(uri.host, 'huggingface.co');
+    });
+
+    test('rejects clear-text and private hosts', () {
+      expect(
+        () => ModelSecurity.requireTrustedDownloadUri(
+            'http://example.com/model.gguf'),
+        throwsFormatException,
+      );
+      expect(
+        () => ModelSecurity.requireTrustedDownloadUri(
+            'https://127.0.0.1/model.gguf'),
+        throwsFormatException,
+      );
+      expect(
+        () => ModelSecurity.requireTrustedDownloadUri(
+            'https://192.168.1.5/model.gguf'),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('ModelSecurity model paths', () {
+    test('preserves ordinary legacy IDs', () {
+      final path = ModelSecurity.resolveModelFilePath(
+        filesDir: '/tmp/cortex-models',
+        modelId: 'gemma-3-4b-q4',
+      );
+      expect(path, p.normalize('/tmp/cortex-models/gemma-3-4b-q4.gguf'));
+    });
+
+    test('prevents traversal outside the model directory', () {
+      final base = p.normalize(p.absolute('/tmp/cortex-models'));
+      final path = ModelSecurity.resolveModelFilePath(
+        filesDir: base,
+        modelId: '../../outside',
+      );
+      expect(p.isWithin(base, path), isTrue);
+      expect(path, isNot(contains('..')));
+    });
+  });
+
+  group('ModelSecurity catalog guards', () {
+    test('rejects empty and catastrophic catalog replacements', () {
+      expect(
+        ModelSecurity.isPlausibleCatalogReplacement(
+            existingCount: 300, incomingCount: 0),
+        isFalse,
+      );
+      expect(
+        ModelSecurity.isPlausibleCatalogReplacement(
+            existingCount: 300, incomingCount: 80),
+        isFalse,
+      );
+      expect(
+        ModelSecurity.isPlausibleCatalogReplacement(
+            existingCount: 300, incomingCount: 200),
+        isTrue,
+      );
+    });
+
+    test('disambiguates duplicate top-level IDs deterministically', () {
+      final result = ModelSecurity.disambiguateDuplicateModelIds([
+        {'id': 'vision', 'producer': 'Google'},
+        {'id': 'vision', 'producer': 'Meta'},
+        {'id': 'unique', 'producer': 'OpenAI'},
+      ]);
+
+      expect(result.map((m) => m['id']).toList(),
+          ['google--vision', 'meta--vision', 'unique']);
+    });
+  });
+
+  test('validates GGUF magic bytes', () async {
+    final dir = await Directory.systemTemp.createTemp('cortex_gguf_test_');
+    addTearDown(() => dir.delete(recursive: true));
+
+    final valid = File(p.join(dir.path, 'valid.gguf'));
+    await valid.writeAsBytes([0x47, 0x47, 0x55, 0x46, 0, 0, 0, 0]);
+    expect(await ModelSecurity.isValidGgufFile(valid), isTrue);
+
+    final invalid = File(p.join(dir.path, 'invalid.gguf'));
+    await invalid.writeAsBytes([0x50, 0x4b, 0x03, 0x04]);
+    expect(await ModelSecurity.isValidGgufFile(invalid), isFalse);
+  });
+}

--- a/test/synapse_client_hardening_test.dart
+++ b/test/synapse_client_hardening_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:cortex/chat/services/utils.dart';
+import 'package:cortex/library/backend/data/entity.dart';
 import 'package:cortex/library/backend/security.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
@@ -86,6 +87,27 @@ void main() {
       expect(result.map((m) => m['id']).toList(),
           ['google--vision', 'meta--vision', 'unique']);
     });
+  });
+
+  test('aggregates image capability from a series vision variant', () {
+    final series = ModelEntity.fromMap({
+      'id': 'claude-series',
+      'title': 'Claude',
+      'producer': 'Anthropic',
+      'type': 'online',
+      'variants': {
+        'Text': {
+          'id': 'anthropic/claude-text',
+          'modalities': {'image': false}
+        },
+        'Vision': {
+          'id': 'anthropic/claude-vision',
+          'modalities': {'image': true}
+        },
+      },
+    }, 'en');
+
+    expect(series.modalities['image'], isTrue);
   });
 
   test('validates GGUF magic bytes', () async {


### PR DESCRIPTION
## Summary

Hardens the Cortex client at the Synapse trust boundary and fixes the model/vision inconsistencies visible in chat. Fulcrum and payment code are untouched.

### Vision / attachment fixes
- ImagePicker selections are classified from the picker action instead of temporary filename extensions.
- Attachment encoding now sniffs MIME from file headers, so extensionless/generic picker cache paths still become `image_url` blocks.
- Series-level input modalities are aggregated from their variants, so the UI correctly knows when a Claude/Llama/etc. series has a vision-capable variant.
- When an image is attached to a server-side model series, Cortex promotes the selected series to an eligible vision variant instead of allowing the request to drift to a text-only variant.
- The send/action gate prevents non-Dynamic selected models from silently sending an image through a model that cannot consume image input.

### Model identity fixes
- Assistant message model IDs are no longer injected into later conversational text as `[Model: ...]`; those IDs are UI/storage metadata only.
- Server-side requests get a deterministic runtime identity derived from the actual selected model. Dynamic Chat identifies itself as Cortex Dynamic Chat instead of inventing a provider/model name.
- Offline/local models receive the runtime identity in the native prompt context as well, preventing a local Llama/Qwen/etc. from claiming it is GPT/Claude based on training data or prior messages.
- Runtime identity space is reserved inside the system prompt budget so long memory/persona prompts cannot truncate it away.

### Catalog synchronization
- Treat non-200, empty, parse-failed, and storage-failed catalog fetches as unsuccessful syncs.
- Do not advance `model_data_last_sync_timestamp` after an unsuccessful/incomplete sync.
- Add a catastrophic-shrink guard: once a meaningful local catalog exists, an incoming catalog with less than 50% of the existing public entries is rejected instead of triggering stale-model cleanup.
- Ignore malformed/local-namespace IDs from the remote public catalog.
- Deterministically disambiguate duplicate top-level model IDs so SQLite `PRIMARY KEY` replacement cannot silently overwrite another producer's series.
- Skip malformed multi-variant entries that do not contain a usable variant ID.

### Offline model downloads
- Require public HTTPS model download URLs; reject clear-text, credential-bearing, loopback, link-local, and private-network destinations.
- Validate the GGUF magic header before marking FlutterDownloader or Dio fallback downloads as complete.
- Delete invalid downloaded payloads instead of registering them as usable local models.

### Model file paths
- Constrain model-derived paths to the configured model directory.
- Preserve legacy paths for IDs that already resolve inside the model directory.
- Map traversal-style IDs that would escape the directory to a deterministic SHA-256-derived filename.

### Tests
`test/synapse_client_hardening_test.dart` covers:
- trusted/untrusted download URLs
- path traversal containment
- catalog shrink protection
- duplicate ID disambiguation
- GGUF magic validation
- extensionless image MIME detection / `image_url` creation
- aggregation of image capability from a series vision variant

## Scope / limitations
- Fulcrum is untouched.
- No new branch was created; this PR uses the pre-existing `fix/synapse-client-hardening` branch.
- This adds file-format validation, not cryptographic model provenance. Full SHA-256 artifact verification would require Synapse (or another trusted manifest) to publish an expected digest for each downloadable GGUF.
- Flutter/Dart SDK is not installed in the execution environment, so `flutter test` / `flutter analyze` could not be run here. CI and maintainer/device validation are required before merge.
