### PR TITLE
fix: harden purchase reconciliation and reduce wasted voice/startup work

### DIFF
--- a/lib/chat/services/tts_remote.dart
+++ b/lib/chat/services/tts_remote.dart
@@ -39,6 +39,8 @@ class RemoteTtsService {
 
   AudioPlayer? _player;
   bool _contextConfigured = false;
+  final Set<CancelToken> _requests = {};
+  int _generation = 0;
 
   /// The voice the user picked, kept here so voice mode does not have to reach
   /// for a provider on every sentence. VoiceCatalogProvider writes it; null
@@ -91,15 +93,20 @@ class RemoteTtsService {
     // An explicit id wins so the settings preview can audition a voice the
     // user has not committed to yet.
     final voice = voiceId ?? activeVoiceId;
+    final generation = _generation;
+    final cancelToken = CancelToken();
+    _requests.add(cancelToken);
 
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) return null;
       final token = await user.getIdToken();
-      if (token == null) return null;
+      if (token == null || cancelToken.isCancelled ||
+          FirebaseAuth.instance.currentUser?.uid != user.uid) return null;
 
       final response = await _dio.post<List<int>>(
         _endpoint,
+        cancelToken: cancelToken,
         data: {
           'text': trimmed,
           if (voice != null && voice.isNotEmpty) 'voiceId': voice,
@@ -115,6 +122,8 @@ class RemoteTtsService {
         ),
       );
 
+      if (generation != _generation ||
+          FirebaseAuth.instance.currentUser?.uid != user.uid) return null;
       if (response.statusCode != 200 || response.data == null) {
         debugPrint("[RemoteTts] Declined: HTTP ${response.statusCode}");
         return null;
@@ -122,8 +131,10 @@ class RemoteTtsService {
       final bytes = Uint8List.fromList(response.data!);
       return bytes.isEmpty ? null : bytes;
     } catch (e) {
-      debugPrint("[RemoteTts] synthesize failed: $e");
+      if (kDebugMode) debugPrint('[RemoteTts] Synthesis unavailable.');
       return null;
+    } finally {
+      _requests.remove(cancelToken);
     }
   }
 
@@ -132,16 +143,18 @@ class RemoteTtsService {
   /// Returns false if playback could not start, so the caller can speak the
   /// same sentence on-device instead of skipping it.
   Future<bool> play(Uint8List bytes) async {
+    StreamSubscription<void>? onComplete;
+    StreamSubscription<PlayerState>? onState;
+    final generation = _generation;
     try {
       final player = await _ensurePlayer();
+      if (generation != _generation) return true;
       await player.stop();
-      await player.play(BytesSource(bytes));
+      if (generation != _generation) return true;
 
       // onPlayerComplete does not fire if playback is stopped from elsewhere,
       // so the state stream is watched as well.
       final completer = Completer<void>();
-      late final StreamSubscription<void> onComplete;
-      late final StreamSubscription<PlayerState> onState;
 
       void finish() {
         if (!completer.isCompleted) completer.complete();
@@ -154,18 +167,25 @@ class RemoteTtsService {
         }
       });
 
+      // Subscribe before play: short clips can finish before play() returns.
+      await player.play(BytesSource(bytes));
       await completer.future;
-      await onComplete.cancel();
-      await onState.cancel();
       return true;
     } catch (e) {
       debugPrint("[RemoteTts] play failed: $e");
       return false;
+    } finally {
+      await onComplete?.cancel();
+      await onState?.cancel();
     }
   }
 
   /// Cuts playback short — used when the user interrupts.
   Future<void> stop() async {
+    _generation++;
+    for (final request in _requests) {
+      request.cancel('Voice interrupted');
+    }
     try {
       await _player?.stop();
     } catch (e) {
@@ -174,6 +194,7 @@ class RemoteTtsService {
   }
 
   Future<void> dispose() async {
+    await stop();
     try {
       await _player?.dispose();
     } catch (_) {}

--- a/lib/purchase_sync_queue.dart
+++ b/lib/purchase_sync_queue.dart
@@ -1,0 +1,29 @@
+/// Serializes store events within one reconciliation session. This is only a
+/// client-side duplicate guard; receipt ownership and idempotency belong on
+/// the server.
+class PurchaseSyncQueue {
+  PurchaseSyncQueue({required this.isSessionCurrent});
+
+  final bool Function() isSessionCurrent;
+  final Set<String> _completed = {};
+  Future<void> _tail = Future<void>.value();
+
+  Future<void> get drained => _tail;
+
+  Future<void> submit({
+    required String key,
+    required Future<void> Function() verify,
+    required Future<void> Function() complete,
+  }) {
+    final task = _tail.then((_) async {
+      if (!isSessionCurrent() || _completed.contains(key)) return;
+      await verify();
+      if (!isSessionCurrent()) return;
+      await complete();
+      _completed.add(key);
+    });
+    // A failed receipt must not poison subsequent events, and is retryable.
+    _tail = task.then<void>((_) {}, onError: (Object _, StackTrace __) {});
+    return task;
+  }
+}

--- a/lib/reconcile.dart
+++ b/lib/reconcile.dart
@@ -1,12 +1,17 @@
 // lib/reconcile.dart
 
 import 'dart:async';
+import 'dart:convert';
+import 'package:crypto/crypto.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
 import 'library/backend/data/database.dart';
+import 'purchase_sync_queue.dart';
+
+Future<void>? _purchaseSync;
 
 /// Reconciles local model counts (roleplay + offline) with remote counts
 /// stored on the server, updating the backend if local counts are higher.
@@ -20,13 +25,17 @@ Future<void> reconcileLocalAndRemoteModelCounts() async {
 
   try {
     final db = await DatabaseHelper.instance.database;
-    final localRoleplayModels =
-        await db?.query('models', where: "id LIKE 'self_%'") ?? [];
-    final localOfflineModels =
-        await db?.query('models', where: "id LIKE 'local_%'") ?? [];
-
-    final int localRoleplayCount = localRoleplayModels.length;
-    final int localOfflineCount = localOfflineModels.length;
+    if (db == null) return;
+    // Count in SQLite instead of transferring every encrypted JSON payload
+    // across the platform channel. GLOB treats the underscore literally.
+    final counts = await db.rawQuery('''
+      SELECT COUNT(CASE WHEN id GLOB 'self_*' THEN 1 END) AS roleplay,
+             COUNT(CASE WHEN id GLOB 'local_*' THEN 1 END) AS offline
+      FROM models
+    ''');
+    final localRoleplayCount = (counts.single['roleplay'] as num).toInt();
+    final localOfflineCount = (counts.single['offline'] as num).toInt();
+    if (FirebaseAuth.instance.currentUser?.uid != user.uid) return;
 
     final userDoc = await FirebaseFirestore.instance
         .collection('users')
@@ -47,6 +56,7 @@ Future<void> reconcileLocalAndRemoteModelCounts() async {
         region: 'europe-west1',
       ).httpsCallable('reconcileModelCounts');
 
+      if (FirebaseAuth.instance.currentUser?.uid != user.uid) return;
       await callable.call({
         'localRoleplayCount': localRoleplayCount,
         'localOfflineCount': localOfflineCount,
@@ -67,13 +77,36 @@ Future<void> reconcileLocalAndRemoteModelCounts() async {
 
 /// Performs a one-shot reconciliation and verification of in-app purchases
 /// with the backend, restoring purchases and verifying them on the server.
-Future<void> reconcileAndSyncPurchases() async {
+Future<void> reconcileAndSyncPurchases() {
+  // Startup/resume callers share one listener and restore operation.
+  return _purchaseSync ??= _runPurchaseSync().whenComplete(() {
+    _purchaseSync = null;
+  });
+}
+
+Future<void> _runPurchaseSync() async {
   debugPrint(
     'Purchase Sync: Starting full purchase reconciliation.',
   );
 
   final InAppPurchase iap = InAppPurchase.instance;
   StreamSubscription<List<PurchaseDetails>>? streamSubscription;
+  StreamSubscription<User?>? authSubscription;
+  final auth = FirebaseAuth.instance;
+  final userId = auth.currentUser?.uid;
+  if (userId == null) return;
+  bool sessionActive = true;
+  final ended = Completer<void>();
+  void endSession() {
+    sessionActive = false;
+    if (!ended.isCompleted) ended.complete();
+  }
+  final queue = PurchaseSyncQueue(
+    isSessionCurrent: () => sessionActive && auth.currentUser?.uid == userId,
+  );
+  authSubscription = auth.authStateChanges().listen((user) {
+    if (user?.uid != userId) endSession();
+  }, onError: (Object _) => endSession());
 
   try {
     final bool isAvailable = await iap.isAvailable();
@@ -84,70 +117,71 @@ Future<void> reconcileAndSyncPurchases() async {
       return;
     }
 
-    if (FirebaseAuth.instance.currentUser == null) {
+    if (!sessionActive || auth.currentUser?.uid != userId) {
       debugPrint('Purchase Sync: No user logged in. Skipping.');
       return;
     }
 
-    final completer = Completer<void>();
     final functions = FirebaseFunctions.instanceFor(region: 'europe-west1');
 
     streamSubscription = iap.purchaseStream.listen(
-      (purchaseDetailsList) async {
-        if (purchaseDetailsList.isEmpty && !completer.isCompleted) {
-          completer.complete();
-          return;
-        }
-
+      (purchaseDetailsList) {
         for (final purchase in purchaseDetailsList) {
           final status = purchase.status;
           if (status == PurchaseStatus.purchased ||
               status == PurchaseStatus.restored) {
-            try {
-              final callable = functions.httpsCallable('verifyPurchase');
-              await callable.call<dynamic>({
-                'receiptData': purchase.verificationData.serverVerificationData,
-                'productId': purchase.productID,
-                'platform': defaultTargetPlatform.name.toLowerCase(),
-              });
-
-              if (purchase.pendingCompletePurchase) {
-                await iap.completePurchase(purchase);
-              }
-            } catch (e) {
-              debugPrint(
-                'Purchase Sync: Server verification failed for '
-                '${purchase.productID}. Error: $e',
-              );
-            }
+            final receipt = purchase.verificationData.serverVerificationData;
+            if (receipt.isEmpty) continue;
+            // Never retain or log a raw receipt as the duplicate key.
+            final key = sha256.convert(utf8.encode(jsonEncode([
+              purchase.productID,
+              purchase.purchaseID,
+              receipt,
+            ]))).toString();
+            unawaited(queue.submit(
+              key: key,
+              verify: () async {
+                final callable = functions.httpsCallable('verifyPurchase');
+                await callable.call<dynamic>({
+                  'receiptData': receipt,
+                  'productId': purchase.productID,
+                  'platform': defaultTargetPlatform.name.toLowerCase(),
+                });
+              },
+              complete: () async {
+                if (purchase.pendingCompletePurchase) {
+                  await iap.completePurchase(purchase);
+                }
+              },
+            ).catchError((Object _) {
+              // Exceptions can contain receipt data. Do not log their payload.
+              if (kDebugMode) debugPrint('Purchase Sync: Verification deferred.');
+            }));
           }
-        }
-
-        if (!completer.isCompleted) {
-          completer.complete();
         }
       },
       onDone: () {
-        if (!completer.isCompleted) completer.complete();
+        if (!ended.isCompleted) ended.complete();
       },
-      onError: (e) {
-        if (!completer.isCompleted) completer.completeError(e);
-      },
+      onError: (Object _) => endSession(),
     );
 
     await iap.restorePurchases();
     await Future.any(
       [
-        completer.future,
+        ended.future,
         Future.delayed(const Duration(seconds: 15)),
       ],
     );
-  } catch (e) {
-    debugPrint(
-      "Purchase Sync: A critical error occurred: $e",
-    );
+  } catch (_) {
+    if (kDebugMode) debugPrint('Purchase Sync: Reconciliation deferred.');
   } finally {
     await streamSubscription?.cancel();
+    // Finish accepted batches before removing the account guard. The first
+    // batch (including an empty batch) is not a store restore-complete signal.
+    await queue.drained;
+    sessionActive = false;
+    await authSubscription?.cancel();
     debugPrint("Purchase Sync: Reconciliation listener cancelled.");
   }
 }

--- a/test/purchase_sync_queue_test.dart
+++ b/test/purchase_sync_queue_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+import 'package:cortex/purchase_sync_queue.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('concurrent duplicate receipts verify and complete once', () async {
+    final queue = PurchaseSyncQueue(isSessionCurrent: () => true);
+    final gate = Completer<void>();
+    var verified = 0;
+    var completed = 0;
+    Future<void> submit() => queue.submit(
+      key: 'receipt',
+      verify: () async { verified++; await gate.future; },
+      complete: () async { completed++; },
+    );
+    final first = submit();
+    final duplicate = submit();
+    gate.complete();
+    await Future.wait([first, duplicate]);
+    expect(verified, 1);
+    expect(completed, 1);
+  });
+
+  test('account change during verification prevents completion and queued work', () async {
+    var current = true;
+    final queue = PurchaseSyncQueue(isSessionCurrent: () => current);
+    var completed = 0;
+    var verified = 0;
+    await queue.submit(
+      key: 'first',
+      verify: () async { current = false; },
+      complete: () async { completed++; },
+    );
+    await queue.submit(
+      key: 'second',
+      verify: () async { verified++; },
+      complete: () async { completed++; },
+    );
+    expect(completed, 0);
+    expect(verified, 0);
+  });
+
+  test('failed verification never completes and can be retried', () async {
+    final queue = PurchaseSyncQueue(isSessionCurrent: () => true);
+    var completed = 0;
+    await expectLater(queue.submit(
+      key: 'receipt',
+      verify: () async { throw StateError('offline'); },
+      complete: () async { completed++; },
+    ), throwsStateError);
+    expect(completed, 0);
+    await queue.submit(
+      key: 'receipt', verify: () async {},
+      complete: () async { completed++; },
+    );
+    expect(completed, 1);
+  });
+
+  test('completion failure is retryable and does not poison queue', () async {
+    final queue = PurchaseSyncQueue(isSessionCurrent: () => true);
+    var completed = 0;
+    await expectLater(queue.submit(
+      key: 'receipt', verify: () async {},
+      complete: () async { throw StateError('store offline'); },
+    ), throwsStateError);
+    await queue.submit(
+      key: 'receipt', verify: () async {},
+      complete: () async { completed++; },
+    );
+    await queue.drained;
+    expect(completed, 1);
+  });
+
+  test('distinct purchases of the same product must not be collapsed', () async {
+    final queue = PurchaseSyncQueue(isSessionCurrent: () => true);
+    var completed = 0;
+    await Future.wait(['transaction1', 'transaction2'].map((key) => queue.submit(
+      key: key, verify: () async {},
+      complete: () async { completed++; },
+    )));
+    expect(completed, 2);
+  });
+}


### PR DESCRIPTION
## Scope
Targeted client hardening and performance fixes, separate from PR #12 and #13. Reuses the existing feat/820-voice-and-credits branch with the user's explicit fast-forward approval. No new remote branch, direct main commit, merge, Synapse or Fulcrum changes.

## Findings and changes
- Concurrent purchase reconciliation calls could create competing restore listeners. They now share a single in-flight operation.
- Async purchase stream callbacks could verify and complete the same receipt concurrently. A serial session-local queue deduplicates successful transactions; failed verification/completion remains retryable. Keys use hashed receipt/transaction identity, not product ID alone.
- Reconciliation had no account-change guard around verification/completion. Auth changes now invalidate the session and skip remaining work; a result from a previous session cannot trigger completion.
- The first purchase batch (even empty) previously ended listening. Keep the existing 15-second observation window and drain accepted batches before cleanup.
- Purchase verification errors and TTS errors are no longer logged with arbitrary exception payloads that may contain sensitive request data.
- Startup model reconciliation now returns aggregate counts from SQLite rather than loading all encrypted model JSON rows. Literal underscore prefix matching also avoids LIKE wildcard miscounts. Account identity is checked again before remote reconciliation.
- Interrupted speech now cancels pending Dio requests, including the token-fetch window, and discards stale/account-mismatched responses.
- Speech completion listeners attach before playback begins and are removed in finally, avoiding missed completion of short clips and listener leaks after playback errors.

## Security boundaries / unresolved backend checks
These are client-side guards, NOT proof that billing fraud is prevented. Server functions, Firestore rules, and referenced funds/server client modules are not included in this checkout.
The server must independently enforce receipt authenticity, product/package/environment validation, transaction ownership, atomic idempotent credit grants, refunds/revocation, and authorization of every paid request. Client model counts must never be trusted as an entitlement authority.
The existing verifyPurchase contract (callable success means verification succeeded; invalid receipts throw) was retained because its backend response schema is unavailable. Confirm this contract before release.
An HTTP cancellation does not guarantee that an already-started provider job stops or that its cost is refunded. No server cancellation or receipt-verification behavior was invented.

## Validation
- PASS: git diff --check.
- PASS: in-memory SQLite checks for counts, literal underscore prefixes, and empty tables.
- Added five Flutter regression tests covering duplicate events, account change, verification failure, completion failure, and distinct transactions.
- BLOCKED: flutter analyze and flutter test test/purchase_sync_queue_test.dart both exit 127; Flutter/Dart SDK absent.
- Android/iOS device build, store sandbox purchases, and audio playback integration are unverified. This checkout also references missing funds/server modules.
- No live financial transactions or production security probes performed.
- No device benchmark or numerical speedup claim.

## Before release
Run Flutter analysis/tests in a complete checkout; exercise multi-batch restores, sign-out during verification, repeated purchases, and short/interrupted audio on Android and iOS. Reconciliation remains a bounded one-shot restore rather than a replacement for a permanent billing listener.