### PR TITLE
perf: reduce repeated model and message work

### DIFF
--- a/lib/chat/messages/messages.dart
+++ b/lib/chat/messages/messages.dart
@@ -17,17 +17,21 @@ class Message {
 
   /// Returns the text completely stripped of any memory tags or their streaming fragments
   /// so that UI elements (like typing animations or raw text selection screens) never show them.
-  String get displayableText {
-    return text
+  // Message text is immutable. Compute once per Message instance, including
+  // streaming copies, instead of re-running both scans on every widget read.
+  static final _partialMemoryTag = RegExp(
+      r'\s*<m(?:e(?:m(?:o(?:r(?:y(?:>[\s\S]*)?)?)?)?)?)?$',
+      caseSensitive: false);
+  static final _memoryTag = RegExp(
+      r'\s*<memory>[\s\S]*?(?:</memory>|$)\s*', caseSensitive: false);
+  late final String _displayableText = text
         .replaceAll(
-            RegExp(r'\s*<m(?:e(?:m(?:o(?:r(?:y(?:>[\s\S]*)?)?)?)?)?)?$',
-                caseSensitive: false),
+            _partialMemoryTag,
             '')
         .replaceAll(
-            RegExp(r'\s*<memory>[\s\S]*?(?:</memory>|$)\s*',
-                caseSensitive: false),
+            _memoryTag,
             '');
-  }
+  String get displayableText => _displayableText;
 
   /// The boolean variable for controlling the message type
   final bool isUserMessage;

--- a/lib/chat/services/database.dart
+++ b/lib/chat/services/database.dart
@@ -11,10 +11,17 @@ class DbHelper {
   DbHelper._internal();
 
   Database? _db;
+  Future<Database>? _openingDb;
   static const int _latestVersion = 11; // Define the latest version here
 
   Future<Database> get db async {
     if (_db != null) return _db!;
+    return _openingDb ??= _open().whenComplete(() {
+      _openingDb = null;
+    });
+  }
+
+  Future<Database> _open() async {
     final dir = await getApplicationDocumentsDirectory();
     final path = join(dir.path, 'chat.sqlite');
     _db = await openDatabase(

--- a/lib/chat/services/storage.dart
+++ b/lib/chat/services/storage.dart
@@ -151,7 +151,7 @@ class ChatStorageService {
           m.photoPath as lastMessagePhoto,
           m.ts as realLastMessageTs
         FROM conversations c
-        LEFT JOIN messages m ON m.idx = (
+        LEFT JOIN messages m ON m.conversationId = c.id AND m.idx = (
             SELECT idx FROM messages 
             WHERE conversationId = c.id 
               AND ((text IS NOT NULL AND length(text) > 0) OR (photoPath IS NOT NULL AND length(photoPath) > 0))

--- a/lib/library/backend/data/database.dart
+++ b/lib/library/backend/data/database.dart
@@ -8,6 +8,7 @@ import 'crypto.dart';
 
 class DatabaseHelper {
   static Database? _database;
+  static Future<Database>? _openingDatabase;
   static final DatabaseHelper instance = DatabaseHelper._privateConstructor();
 
   DatabaseHelper._privateConstructor();
@@ -17,8 +18,14 @@ class DatabaseHelper {
     if (kIsWeb) return null;
 
     if (_database != null) return _database!;
-    _database = await _initDatabase();
-    return _database!;
+    // Share the whole initialization, including getDatabasesPath/onCreate.
+    // Clear failures as well so a later call can retry.
+    return _openingDatabase ??= _initDatabase().then((db) {
+      _database = db;
+      return db;
+    }).whenComplete(() {
+      _openingDatabase = null;
+    });
   }
 
   Future<Database> _initDatabase() async {

--- a/lib/library/backend/data/service.dart
+++ b/lib/library/backend/data/service.dart
@@ -45,6 +45,16 @@ class ModelService with ChangeNotifier {
   List<ModelEntity>? _cachedEntities;
   String? _cachedEntitiesLangCode;
   Future<List<ModelEntity>?>? _pendingFetch;
+  final Map<String, bool> _imageFileChecks = {};
+
+  bool _imageFileExists(String path) {
+    if (_imageFileChecks.isEmpty) {
+      // Coalesce repeated lookups within this synchronous render/build only.
+      // Do not keep stale existence results across later event-loop turns.
+      scheduleMicrotask(_imageFileChecks.clear);
+    }
+    return _imageFileChecks.putIfAbsent(path, () => File(path).existsSync());
+  }
 
   // --- Public API ---
 
@@ -64,6 +74,10 @@ class ModelService with ChangeNotifier {
   /// Returns a list of [ModelEntity] objects, or null on a critical failure.
   Future<List<ModelEntity>?> getModels({required String langCode}) {
     if (_pendingFetch != null) return _pendingFetch!;
+    if (!_hasError && _cachedEntities?.isNotEmpty == true &&
+        _cachedEntitiesLangCode == _normalizeLangCode(langCode)) {
+      return Future.value(_cachedEntities);
+    }
     _pendingFetch = _getModelsInternal(langCode: langCode).whenComplete(() {
       _pendingFetch = null;
     });
@@ -574,7 +588,7 @@ class ModelService with ChangeNotifier {
 
     if (cachedImagePaths.containsKey(model.id)) {
       final localPath = cachedImagePaths[model.id]!;
-      if (File(localPath).existsSync()) {
+      if (_imageFileExists(localPath)) {
         return localPath;
       }
     }
@@ -607,7 +621,7 @@ class ModelService with ChangeNotifier {
       return model.imagePath!;
     }
 
-    if (model.imagePath != null && File(model.imagePath!).existsSync()) {
+    if (model.imagePath != null && _imageFileExists(model.imagePath!)) {
       return model.imagePath!;
     }
 

--- a/lib/library/backend/data/service.dart
+++ b/lib/library/backend/data/service.dart
@@ -45,6 +45,7 @@ class ModelService with ChangeNotifier {
   List<ModelEntity>? _cachedEntities;
   String? _cachedEntitiesLangCode;
   Future<List<ModelEntity>?>? _pendingFetch;
+  String? _pendingFetchLanguage;
   final Map<String, bool> _imageFileChecks = {};
 
   bool _imageFileExists(String path) {
@@ -73,13 +74,21 @@ class ModelService with ChangeNotifier {
   ///
   /// Returns a list of [ModelEntity] objects, or null on a critical failure.
   Future<List<ModelEntity>?> getModels({required String langCode}) {
-    if (_pendingFetch != null) return _pendingFetch!;
+    final language = _normalizeLangCode(langCode);
+    if (_pendingFetch != null) {
+      if (_pendingFetchLanguage == language) return _pendingFetch!;
+      // A request in another language must not receive the first caller's
+      // localized list. Serialize it, then re-use/rebuild the proper cache.
+      return _pendingFetch!.then((_) => getModels(langCode: langCode));
+    }
     if (!_hasError && _cachedEntities?.isNotEmpty == true &&
-        _cachedEntitiesLangCode == _normalizeLangCode(langCode)) {
+        _cachedEntitiesLangCode == language) {
       return Future.value(_cachedEntities);
     }
+    _pendingFetchLanguage = language;
     _pendingFetch = _getModelsInternal(langCode: langCode).whenComplete(() {
       _pendingFetch = null;
+      _pendingFetchLanguage = null;
     });
     return _pendingFetch!;
   }

--- a/test/message_display_cache_test.dart
+++ b/test/message_display_cache_test.dart
@@ -1,0 +1,30 @@
+import 'package:cortex/chat/messages/messages.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('cached display text preserves existing memory-tag filtering', () {
+    final partial = RegExp(
+        r'\s*<m(?:e(?:m(?:o(?:r(?:y(?:>[\s\S]*)?)?)?)?)?)?$',
+        caseSensitive: false);
+    final complete = RegExp(r'\s*<memory>[\s\S]*?(?:</memory>|$)\s*',
+        caseSensitive: false);
+    for (final text in [
+      '', 'Normal response', 'Merhaba 🌍', 'A <memory>private</memory> B',
+      'Answer <mem', 'Answer <MEMORY>pending',
+      'First\n<memory>line one\nline two</memory>\nLast',
+    ]) {
+      final message = Message(text: text, isUserMessage: false);
+      final expected = text.replaceAll(partial, '').replaceAll(complete, '');
+      expect(message.displayableText, expected);
+      expect(message.displayableText, expected);
+    }
+  });
+
+  test('streaming copy computes from its own updated text', () {
+    final original = Message(text: 'First', isUserMessage: false);
+    expect(original.displayableText, 'First');
+    final next = original.copyWith(text: 'Second <memory>hidden</memory>');
+    expect(next.displayableText, 'Second');
+    expect(original.displayableText, 'First');
+  });
+}

--- a/test/storage_query_regression_test.py
+++ b/test/storage_query_regression_test.py
@@ -1,0 +1,78 @@
+"""Run the actual Dart inbox SQL with Python's standard-library SQLite.
+
+This tests query semantics without requiring Flutter or Firebase.
+Run: python -m unittest discover -s test -p storage_query_regression_test.py
+"""
+from pathlib import Path
+import re
+import sqlite3
+import unittest
+
+
+class InboxQueryTest(unittest.TestCase):
+    def setUp(self):
+        source = (Path(__file__).resolve().parents[1] /
+                  'lib/chat/services/storage.dart').read_text()
+        section = source.split('getConversationsWithLastMessage() async', 1)[1]
+        self.query = re.search(r"rawQuery\('''(.*?)'''\)", section, re.S).group(1)
+        self.db = sqlite3.connect(':memory:')
+        self.addCleanup(self.db.close)
+        self.db.row_factory = sqlite3.Row
+        self.db.executescript('''
+          CREATE TABLE conversations (
+            id TEXT PRIMARY KEY, title TEXT, modelId TEXT, modelTitle TEXT,
+            modelImagePath TEXT, isStarred INTEGER, starredDate INTEGER,
+            lastMessageDate INTEGER);
+          CREATE TABLE messages (
+            conversationId TEXT, idx INTEGER, text TEXT, photoPath TEXT,
+            ts INTEGER);
+          CREATE UNIQUE INDEX messages_conv_idx ON messages(conversationId, idx);
+        ''')
+
+    def conversation(self, identifier):
+        self.db.execute('INSERT INTO conversations(id) VALUES (?)', (identifier,))
+
+    def message(self, identifier, idx, text='', photo=None):
+        self.db.execute('INSERT INTO messages VALUES (?, ?, ?, ?, ?)',
+                        (identifier, idx, text, photo, idx))
+
+    def test_matching_indices_do_not_cross_conversations(self):
+        for name in ['a', 'b']:
+            self.conversation(name)
+            self.message(name, 0, name + ' first')
+            self.message(name, 1, name + ' last')
+        rows = self.db.execute(self.query).fetchall()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual({r['id']: r['lastMessageText'] for r in rows},
+                         {'a': 'a last', 'b': 'b last'})
+
+    def test_empty_conversation_and_trailing_placeholder(self):
+        self.conversation('empty')
+        self.conversation('active')
+        self.message('active', 0, 'visible')
+        self.message('active', 1)
+        rows = {r['id']: r for r in self.db.execute(self.query)}
+        self.assertIsNone(rows['empty']['lastMessageText'])
+        self.assertEqual(rows['active']['lastMessageText'], 'visible')
+
+    def test_attachment_only_message_remains_visible(self):
+        self.conversation('media')
+        self.message('media', 0, 'earlier')
+        self.message('media', 1, photo='["image.jpg"]')
+        row = self.db.execute(self.query).fetchone()
+        self.assertEqual(row['lastMessagePhoto'], '["image.jpg"]')
+
+    def test_result_count_does_not_grow_quadratically(self):
+        for number in range(100):
+            identifier = str(number)
+            self.conversation(identifier)
+            self.message(identifier, 0, identifier)
+        rows = self.db.execute(self.query).fetchall()
+        self.assertEqual(len(rows), 100)
+        plan = ' '.join(str(tuple(row)) for row in self.db.execute(
+            'EXPLAIN QUERY PLAN ' + self.query))
+        self.assertIn('messages_conv_idx', plan)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Changes
- Share the full asynchronous database initialization between concurrent callers; clear failed initialization so subsequent calls can retry.
- Return a healthy, language-matched model cache without toggling loading state or notifying every subscriber twice.
- Reuse identical image existence checks within one synchronous build/event turn; clear the map in a microtask so later turns recheck disk.
- Compile message memory-filter regexes once and lazily cache display text per immutable Message. Streaming copyWith objects compute their own result.

No model quality, sampler, feature, image resolution or animation changes. No Fulcrum/Synapse/payment modifications. Existing branch reused with user approval; base main, separate from PRs #12–15.

## Validation
- PASS git diff --check.
- PASS uploaded blobs match local commit hashes.
- Added display-filter equivalence and streaming-copy regression tests.
- BLOCKED flutter analyze and flutter test test/message_display_cache_test.dart test/messages_test.dart test/model_test.dart: Flutter SDK absent.
- No device profiling or numeric speedup claim. Native builds not run for this Dart-only change.

## Limits / risks
This is a focused first performance pass, not a claim that every screen is faster. First image-file lookup per turn remains synchronous; only repeated checks are removed. Message display caching retains a derived string until that message is collected. Database initialization and cached-list notification behavior require integration verification in a complete Flutter environment.
Async reconstruction of editing attachments was investigated but deferred to avoid introducing unverified edit/cancel/send races.
The separately reported local-model empty-response problem is not addressed by this general-performance PR.

## Additional general-performance / correctness pass
- Fix the inbox last-message LEFT JOIN to match both conversationId and idx. idx is only unique within a conversation; matching idx alone leaks snippets between conversations and multiplies returned rows. Verified this missing predicate also exists on current main.
- Coalesce chat database initialization (in addition to the model database initialization above), preserving failure retries and the existing schema/migrations.
- Coalesce model fetches only for matching normalized languages; a concurrent request in a different language waits and then obtains its own localized result.

## Additional verification
- PASS: four Python standard-library SQLite regression tests execute SQL extracted directly from storage.dart. Coverage: matching indices in different conversations, empty chats/trailing placeholders, attachment-only messages, and result cardinality/index use.
- Controlled fixture: 100 conversations with one idx=0 message each returned 10,000 rows before the join fix and exactly 100 afterward. This measures erroneous result multiplication, not an app-wide speedup percentage.
- PASS: git diff --check and uploaded blob hash equality.
- BLOCKED: flutter analyze (SDK absent). Dart runtime/concurrency and device UI timings remain unverified; no claim of full-app performance validation.

No feature, model quality, history, animation, or safety instruction removed. No destructive migration or backend change. These additions remain on the same main-targeted PR; do not merge automatically.